### PR TITLE
fix(topol): fix reading level description

### DIFF
--- a/TOPOL.CPP
+++ b/TOPOL.CPP
@@ -164,6 +164,9 @@ const char* getleveldescription(int level) {
             if (strchr(Sor, '\n')) {
                 *strchr(Sor, '\n') = 0;
             }
+            if (strchr(Sor, '\r')) {
+                *strchr(Sor, '\r') = 0;
+            }
             if (strlen(Sor) > DESCNEVHOSSZ) {
                 hiba("tct86");
             }


### PR DESCRIPTION
On Windows opening a file in rt mode strips the \r character macos does not do this and the \r character will still be present so we need to replace any possible \r characters.