### PR TITLE
chore: configure minimum meson version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('elma', 'cpp', version: '1.4', default_options: ['cpp_std=c++20'])
+project('elma', 'cpp', version: '1.4', meson_version: '>=1.2.0', default_options: ['cpp_std=c++20'])
 
 if get_option('buildtype') == 'debug'
     add_project_arguments('-DDEBUG', language: 'cpp')


### PR DESCRIPTION
Fixes this warning:

WARNING: Project specifies no minimum version but uses features which were added in versions:
 * 1.2.0: {'"dependency" keyword argument "default_options" of type dict'}