### PR TITLE
fix(asan): fix overflow read in render_error()

### DIFF
--- a/menu_pic.cpp
+++ b/menu_pic.cpp
@@ -462,7 +462,7 @@ void render_error(const char* text1, const char* text2, const char* text3) {
                 strncpy(ErrorLines[line_count], text, j);
                 line_count++;
                 text += j;
-                while (text[j] == ' ') {
+                while (text[0] == ' ') {
                     text++;
                 }
             }


### PR DESCRIPTION
The code is trying to try excess blank space, but is using `j` as an index, but should be clearing from the start of the text.

```
==31584==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00010228ef16 at pc 0x00010223a064 bp 0x00016dc55c10 sp 0x00016dc55c08
READ of size 1 at 0x00010228ef16 thread T0
    #0 0x00010223a060 in render_error(char const*, char const*, char const*) menu_pic.cpp:465
    #1 0x000102233928 in directhiba(char const*, char const*, char const*, char const*) MAIN.CPP:71
    #2 0x0001022335b0 in hiba(char const*, char const*, char const*) MAIN.CPP:100
    #3 0x000102237058 in menu_pic::add_line(char const*, int, int) menu_pic.cpp:70
    #4 0x000102276f4c in menu_nav::navigate(text_line*, int, bool) menu_nav.cpp:250
    #5 0x00010223bc7c in options() OPTIONS.CPP:178
    #6 0x000102235be0 in mainmenu() MAINMENU.CPP:361
    #7 0x000102209060 in jatekosvalasztas(int, int) JATEKOS.CPP:190
    #8 0x000102260d44 in teljes() TELJES.CPP:180
    #9 0x000102233518 in main MAIN.CPP:20
    #10 0x0001880add50  (<unknown module>)

0x00010228ef16 is located 42 bytes before global variable '.str' defined in '../OPTIONS.CPP' (0x00010228ef40) of size 18
  '.str' is ascii string 'Default controls:'
0x00010228ef16 is located 7 bytes after global variable '.str.9' defined in '../menu_pic.cpp' (0x00010228eee0) of size 47
  '.str.9' is ascii string 'menu::add_line linecount >= MENU_MAX_LINES - 1'
SUMMARY: AddressSanitizer: global-buffer-overflow menu_pic.cpp:465 in render_error(char const*, char const*, char const*)
```