### PR TITLE
fix(palette): set palette before unlocking/blitting surface

### DIFF
--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -511,13 +511,12 @@ long lejatszo(const char* filenev) {
                       meghalt2);
         }
 
-        kirajzol320(eddig, &valt1, &valt2, Viewtime1.viewkinplay, Viewtime1.timekinplay,
-                    Viewtime2.viewkinplay, Viewtime2.timekinplay);
-
         if (palmegnincs) {
             palmegnincs = 0;
             Plgr->pal->set();
         }
+        kirajzol320(eddig, &valt1, &valt2, Viewtime1.viewkinplay, Viewtime1.timekinplay,
+                    Viewtime2.viewkinplay, Viewtime2.timekinplay);
 
         // Egy par kozos toggle:
         // Plusz elintezes:
@@ -809,13 +808,12 @@ long lejatszo_r(const char* filenev, int showkepmarad) {
         }
 
         // KIRAJZOLAS:
-        kirajzol320(eddig, &valt1, &valt2, Viewtime1.viewkinreplay, Viewtime1.timekinreplay,
-                    Viewtime2.viewkinreplay, Viewtime2.timekinreplay);
-
         if (palmegnincs) {
             palmegnincs = 0;
             Plgr->pal->set();
         }
+        kirajzol320(eddig, &valt1, &valt2, Viewtime1.viewkinreplay, Viewtime1.timekinreplay,
+                    Viewtime2.viewkinreplay, Viewtime2.timekinreplay);
 
         // Egy par kozos toggle:
         // Plusz elintezes:

--- a/menu_pic.cpp
+++ b/menu_pic.cpp
@@ -485,8 +485,8 @@ void render_error(const char* text1, const char* text2, const char* text3) {
         MenuFont->write_centered(BufferMain, SCREEN_WIDTH / 2, y, ErrorLines[i]);
     }
     // Display the error message
-    bltfront(BufferMain);
     if (MenuPal) {
         MenuPal->set();
     }
+    bltfront(BufferMain);
 }


### PR DESCRIPTION
In DirectX, setting the palette immediately updates the screen, so there is less palette flicker if you set it right after unlocking the surface. In SDL this doesn't work and the palette needs to be set before updating the screen as the palette isn't directly linked to the real surface

Fixes https://github.com/elmadev/elma-classic/issues/104