### PR TITLE
refactor: make double->int conversions explicit

### DIFF
--- a/DOBOZ.CPP
+++ b/DOBOZ.CPP
@@ -255,8 +255,8 @@ void dobozki(pic8* ppic8, affine_pic* pkiskep, vect2 u, vect2 v, vect2 r) {
     //	return;
 
     // Kivalasztjuk egesz kezdopontot:
-    int xbal = csucs.x;
-    int ybal = csucs.y;
+    int xbal = (int)(csucs.x);
+    int ybal = (int)(csucs.y);
     double szint = ybal;
 
     // Kiszamolja hatarolo egyenesek parametereit:

--- a/ECSET.CPP
+++ b/ECSET.CPP
@@ -72,7 +72,7 @@ mdarab* ecset::newmdarab(void) {
 }
 
 static void meghelyez(double* pd) {
-    int pixel = *pd * MetersToPixels;
+    int pixel = (int)(*pd * MetersToPixels);
     *pd = (pixel + 0.5) / MetersToPixels;
 }
 
@@ -166,8 +166,8 @@ void ecset::addszakasz(vonal* psz) {
     if (v.y < 0.001) {
         return;
     }
-    int y1 = r.y + 1;
-    int y2 = r.y + v.y;
+    int y1 = (int)(r.y + 1.0);
+    int y2 = (int)(r.y + v.y);
 
     /*double kozelseg = 0.000001;
     if( fabs( double( y1 )-(r.y+1) ) < kozelseg )
@@ -183,7 +183,7 @@ void ecset::addszakasz(vonal* psz) {
     double dx2 = r.x + v.x;
     double a = (dx2 * dy1 - dx1 * dy2) / (dy1 - dy2);
     for (int y = y1; y <= y2; y++) {
-        int x = m * y + a + 1.0;
+        int x = (int)(m * y + a + 1.0);
         // if( fabs( double(x)-m*y+a+1.0 ) < kozelseg )
         //	internal_error( "Nagyon kozeli pont!" );
 
@@ -459,11 +459,11 @@ void ecset::kitoltfoodkoordokat(void) {
             continue;
         }
         if (view) {
-            pker->rxint_v = (pker->r.x - origo.x) * MetersToPixels / MinimapScaleFactor;
-            pker->ryint_v = (-pker->r.y - origo.y) * MetersToPixels / MinimapScaleFactor;
+            pker->rxint_v = (int)((pker->r.x - origo.x) * MetersToPixels / MinimapScaleFactor);
+            pker->ryint_v = (int)((-pker->r.y - origo.y) * MetersToPixels / MinimapScaleFactor);
         } else {
-            pker->rxint = (pker->r.x - origo.x) * MetersToPixels - ANIM_WIDTH / 2;
-            pker->ryint = (-pker->r.y - origo.y) * MetersToPixels - ANIM_WIDTH / 2;
+            pker->rxint = (int)((pker->r.x - origo.x) * MetersToPixels - (double)(ANIM_WIDTH / 2));
+            pker->ryint = (int)((-pker->r.y - origo.y) * MetersToPixels - (double)(ANIM_WIDTH / 2));
         }
     }
 }
@@ -751,8 +751,8 @@ int teliszam(int x, int xsize, unsigned char* sor, unsigned char lyuk) {
 // addspriteok hivja:
 void ecset::addegymaszk(sprite* psp, int index_t, int index_m, int fazis) {
     // Egy kep berakasa:
-    int x1 = (psp->r.x - origo.x) * MetersToPixels;
-    int y1 = (-psp->r.y - origo.y) * MetersToPixels;
+    int x1 = (int)((psp->r.x - origo.x) * MetersToPixels);
+    int y1 = (int)((-psp->r.y - origo.y) * MetersToPixels);
 
     maszk* pm = &Plgr->maszkok[index_m];
 
@@ -831,8 +831,8 @@ void ecset::addspriteok(int fazis) {
         kep* pkep = &Plgr->kepek[index];
 
         // Egy kep berakasa:
-        int x1 = (psp->r.x - origo.x) * MetersToPixels;
-        int y1 = (-psp->r.y - origo.y) * MetersToPixels;
+        int x1 = (int)((psp->r.x - origo.x) * MetersToPixels);
+        int y1 = (int)((-psp->r.y - origo.y) * MetersToPixels);
 
         int ujtavolsag = psp->tavolsag;
 
@@ -1175,8 +1175,8 @@ void ecset::addobjektumok(void) {
                 mut = Plgr->viewkiller;
                 ujtavolsag = 499;
             }
-            int x1 = (pk->r.x - origo.x) * (MetersToPixels / MinimapScaleFactor);
-            int y1 = (-pk->r.y - origo.y) * (MetersToPixels / MinimapScaleFactor);
+            int x1 = (int)((pk->r.x - origo.x) * (MetersToPixels / MinimapScaleFactor));
+            int y1 = (int)((-pk->r.y - origo.y) * (MetersToPixels / MinimapScaleFactor));
             // Kirakja kis 3x3-as gyurut:
             addbytesor(mut, ujtavolsag, x1 - 1, x1 + 1, y1 - 1, FAZIS_NEMFOLDEG);
             addbytesor(mut, ujtavolsag, x1 - 1, x1 - 1, y1, FAZIS_NEMFOLDEG);
@@ -1285,11 +1285,11 @@ ecset::ecset(int view_p) {
 
     if (view) {
         // VIEW VIEW VIEW:
-        maxx = xsizedb * (MetersToPixels / MinimapScaleFactor);
-        sorszam = ysizedb * (MetersToPixels / MinimapScaleFactor);
+        maxx = (int)(xsizedb * (MetersToPixels / MinimapScaleFactor));
+        sorszam = (int)(ysizedb * (MetersToPixels / MinimapScaleFactor));
     } else {
-        maxx = xsizedb * MetersToPixels;
-        sorszam = ysizedb * MetersToPixels;
+        maxx = (int)(xsizedb * MetersToPixels);
+        sorszam = (int)(ysizedb * MetersToPixels);
     }
 
     if (sorszam - 10 > MAXECSETSOR) {
@@ -1687,11 +1687,11 @@ void ecset::kiegysor_B(unsigned char* pc, int ye) {
 void ecset::getbalalso_int(vect2 balalso, int* px, int* py) {
     vect2 relat = balalso - origo;
     if (view) {
-        *px = relat.x * (MetersToPixels / MinimapScaleFactor); // Ecset egesz koordinatak
-        *py = relat.y * (MetersToPixels / MinimapScaleFactor); // Ecset egesz koordinatak
+        *px = (int)(relat.x * (MetersToPixels / MinimapScaleFactor)); // Ecset egesz koordinatak
+        *py = (int)(relat.y * (MetersToPixels / MinimapScaleFactor)); // Ecset egesz koordinatak
     } else {
-        *px = relat.x * MetersToPixels; // Ecset egesz koordinatak
-        *py = relat.y * MetersToPixels; // Ecset egesz koordinatak
+        *px = (int)(relat.x * MetersToPixels); // Ecset egesz koordinatak
+        *py = (int)(relat.y * MetersToPixels); // Ecset egesz koordinatak
     }
 }
 

--- a/KIRAJ320.CPP
+++ b/KIRAJ320.CPP
@@ -51,8 +51,8 @@ static int Viewxorig, Viewxtolas;
 void beallitmereteket(int splitscreen) {
     Cy1Bplayer = 100, Cy2Bplayer = 200;
 
-    Cxsize = SCREEN_WIDTH * (Kepmeret * 1.001);
-    Cysize = SCREEN_HEIGHT * (Kepmeret * 1.001);
+    Cxsize = (int)(SCREEN_WIDTH * (Kepmeret * 1.001));
+    Cysize = (int)(SCREEN_HEIGHT * (Kepmeret * 1.001));
     Cx1 = (SCREEN_WIDTH - Cxsize) / 2;
     Cy1 = (SCREEN_HEIGHT - Cysize) / 2;
     Cx2 = Cx1 + Cxsize - 1;
@@ -84,9 +84,9 @@ void beallitmereteket(int splitscreen) {
     Mo_dx = Cxsize / MetersToPixels - 2.0 * Mo_bal;
     Mo_y = Cysize / MetersToPixels / 2.0;
 
-    Viewxsize = 140 * sqrt(double(Cysize) / double(SCREEN_HEIGHT)); // 200
-    Viewysize = 70 * sqrt(double(Cysize) / double(SCREEN_HEIGHT));  // 80
-    Viewxorig = 40 * (Kepmeret - 0.6) / 0.4;
+    Viewxsize = (int)(140.0 * sqrt(double(Cysize) / double(SCREEN_HEIGHT))); // 200
+    Viewysize = (int)(70.0 * sqrt(double(Cysize) / double(SCREEN_HEIGHT)));  // 80
+    Viewxorig = (int)(40.0 * (Kepmeret - 0.6) / 0.4);
     Viewxtolas = Cxsize - 2 * Viewxorig - Viewxsize;
 }
 
@@ -223,7 +223,7 @@ static void kiview(int ajatekos, pic8* ppic, double baljobb, vect2 motorkozep, m
         align = 1.0;
         break;
     }
-    int vx1 = Viewxorig + align * Viewxtolas;
+    int vx1 = (int)(Viewxorig + align * Viewxtolas);
     int vx2 = vx1 + Viewxsize - 1;
     int vy1 = 1;
     int vy2 = vy1 + Viewysize - 1;
@@ -277,16 +277,16 @@ static void kiview(int ajatekos, pic8* ppic, double baljobb, vect2 motorkozep, m
     // Most kirajzoljuk masik (hatso) motorost:
     if (pmot2) {
         vect2 sarokrel = pmot2->bike.r - sarok;
-        int mx = sarokrel.x * MetersToPixels / MinimapScaleFactor + vx1;
-        int my = sarokrel.y * MetersToPixels / MinimapScaleFactor + vy1;
+        int mx = (int)(sarokrel.x * MetersToPixels / MinimapScaleFactor + vx1);
+        int my = (int)(sarokrel.y * MetersToPixels / MinimapScaleFactor + vy1);
         if (mx >= vx1 && mx <= vx2 && my >= vy1 && my <= vy2) {
             kigyuru(ppic, mx, my, viewindex2);
         }
     }
 
     // Most kirajzoljuk elso motorost:
-    int mx = sarokbolkozepre.x * MetersToPixels / MinimapScaleFactor;
-    int my = sarokbolkozepre.y * MetersToPixels / MinimapScaleFactor;
+    int mx = (int)(sarokbolkozepre.x * MetersToPixels / MinimapScaleFactor);
+    int my = (int)(sarokbolkozepre.y * MetersToPixels / MinimapScaleFactor);
     kigyuru(ppic, vx1 + mx, vy1 + my, viewindex1);
 
     // Kirajzoljuk keretet:
@@ -444,7 +444,7 @@ static void kibike(int ajatekos, pic8* ppic, double t, vect2 sarok, motorst* pmo
         }
 
         if (!flages && FlagTagImmunity) {
-            int egeszido = t * 30.0;
+            int egeszido = (int)(t * 30.0);
             if (egeszido % 2) {
                 flages = 1;
             }
@@ -637,11 +637,11 @@ static void kirakegyjatekost(int ajatekos, pic8* ppic, double t, motorst* pmot, 
             switch (pker->tipus) {
             case T_KAJA:
                 pobjpic = Plgr->foodtomb[pker->foodsorszam % Plgr->foodszam]->get_frame_by_time(t);
-                dy = 5 * sin(t * 15.5 + pker->sinfazis);
+                dy = (int)(5.0 * sin(t * 15.5 + pker->sinfazis));
                 break;
             case T_CEL:
                 pobjpic = Plgr->pexit->get_frame_by_time(t);
-                dy = 5 * sin(t * 15.5 + pker->sinfazis);
+                dy = (int)(5.0 * sin(t * 15.5 + pker->sinfazis));
                 break;
             case T_HALALOS:
                 pobjpic = Plgr->pkiller->get_frame_by_time(t);

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -471,7 +471,7 @@ long lejatszo(const char* filenev) {
                 } else {
                     startwave(WAV_TORES, 0.999);
                 }
-                hangosdelay(LevelEndDelay * 1000.0);
+                hangosdelay((int)(LevelEndDelay * 1000.0));
 
                 stopmotor(1);
                 stopmotor(0);
@@ -552,7 +552,7 @@ long lejatszo(const char* filenev) {
             // Kiirja framerate-et:
             double tpl = double(l) / eltelido;
             tpl *= 182;
-            int framerate = tpl;
+            int framerate = (int)(tpl);
             if (access("f_rate.inf", 0) == 0) {
                 // igyhagyni fopen-t!:
                 FILE* h = fopen("f_rate.inf", "wt");
@@ -775,7 +775,7 @@ long lejatszo_r(const char* filenev, int showkepmarad) {
             stopmotor(1);
             stopmotor(0);
             setsurlodas(0);
-            hangosdelay(LevelEndDelay * 400.0);
+            hangosdelay((int)(LevelEndDelay * 400.0));
 
             Mute = 1;
             Ptop->kerekjolalljon();
@@ -845,7 +845,7 @@ long lejatszo_r(const char* filenev, int showkepmarad) {
             // Kiirja framerate-et:
             double tpl = double(l) / eltelido;
             tpl *= 182;
-            int framerate = tpl;
+            int framerate = (int)(tpl);
             if (access("f_rate.inf", 0) == 0) {
                 // igyhagyni fopen-t!:
                 FILE* h = fopen("f_rate.inf", "wt");
@@ -861,7 +861,7 @@ long lejatszo_r(const char* filenev, int showkepmarad) {
             stopmotor(1);
             stopmotor(0);
             setsurlodas(0);
-            hangosdelay(LevelEndDelay * 400.0);
+            hangosdelay((int)(LevelEndDelay * 400.0));
 
             Mute = 1;
 

--- a/MAINMENU.CPP
+++ b/MAINMENU.CPP
@@ -231,7 +231,7 @@ void replay(void) {
                     ido = Prec2->betoltve;
                 }
 
-                ido *= 3.3333333333333;
+                ido = (int)(ido * 3.3333333333333);
                 ido -= 2;
                 if (ido < 1) {
                     ido = 1;

--- a/RECORDER.CPP
+++ b/RECORDER.CPP
@@ -167,7 +167,7 @@ int recorder::recall(motorst* pmot, double ido, hanginfo* phinfo) {
         internal_error("recall-ban betoltve <= 0!");
     }
 
-    int index1 = Recorderszorzo * ido;
+    int index1 = (int)(Recorderszorzo * ido);
     double suly2 = Recorderszorzo * ido - index1;
     if (suly2 < 0.0) {
         suly2 = 0.0;

--- a/SZAKASZ.CPP
+++ b/SZAKASZ.CPP
@@ -174,12 +174,12 @@ void szakaszok::beindexelvonalat(vonal* pv, double maxtav) {
     double xkezdo = r.x - maxtav;
     int cellax = 0;
     if (xkezdo > 0) {
-        cellax = xkezdo;
+        cellax = (int)(xkezdo);
     }
     if (r.x + v.x + maxtav < 0) {
         internal_error("szakaszok::beindexelvonalat-ban r.x+v.x+maxtav < 0!");
     }
-    int ucsocellax = r.x + v.x + maxtav;
+    int ucsocellax = (int)(r.x + v.x + maxtav);
     while (cellax <= ucsocellax) {
         double y1 = m * cellax + y0;
         double y2 = m * (cellax + 1) + y0;
@@ -201,9 +201,9 @@ void szakaszok::beindexelvonalat(vonal* pv, double maxtav) {
         }
         int cellay = 0;
         if (y1 > 0) {
-            cellay = y1;
+            cellay = (int)(y1);
         }
-        int ucsocellay = y2;
+        int ucsocellay = (int)(y2);
         while (cellay <= ucsocellay) {
             if (invertalt) {
                 bekot(cellay, cellax, pv);
@@ -281,8 +281,8 @@ void szakaszok::rendez(double maxtav) {
     double ysized = maxy - miny;
 
     // Kiszamolja dimenziot:
-    xdim = xsized / cellameret + 1;
-    ydim = ysized / cellameret + 1;
+    xdim = (int)(xsized / cellameret + 1.0);
+    ydim = (int)(ysized / cellameret + 1.0);
     if (xdim < 0 || ydim < 0) {
         internal_error("xdim < 0 || ydim < 0!");
     }
@@ -317,11 +317,11 @@ void szakaszok::felsorolasreset(vect2 r) {
     r = (r - origo) * (1 / cellameret);
     int cellax = 0;
     if (r.x > 0) {
-        cellax = r.x;
+        cellax = (int)(r.x);
     }
     int cellay = 0;
     if (r.y > 0) {
-        cellay = r.y;
+        cellay = (int)(r.y);
     }
 
     if (cellax > xdim) {

--- a/TOPOL.CPP
+++ b/TOPOL.CPP
@@ -1150,7 +1150,7 @@ void topol::loadkulso(const char* filenev) {
         internal_error("topol::topol-ban nem tudta olvasni lebego gyuruszamot!");
     }
 
-    int gyuruszam = gyuruolvszam;
+    int gyuruszam = (int)(gyuruolvszam);
     if (gyuruszam > MAXGYURU) {
         internal_error("topol::topol-ban gyuruszam > MAXGYURU!: ");
     }
@@ -1169,7 +1169,7 @@ void topol::loadkulso(const char* filenev) {
         internal_error("topol::topol-ban nem tudta olvasni lebego kerekszamot!");
     }
 
-    int kerekszam = kerekolvszam;
+    int kerekszam = (int)(kerekolvszam);
     if (kerekszam > MAXKEREK) {
         internal_error("topol::topol-ban kerekszam > MAXKEREK!: ");
     }
@@ -1190,7 +1190,7 @@ void topol::loadkulso(const char* filenev) {
             internal_error("topol::topol-ban nem tudta olvasni lebego spriteszamot!");
         }
 
-        int spriteszam = spriteolvszam;
+        int spriteszam = (int)(spriteolvszam);
         if (spriteszam > MAXSPRITE) {
             internal_error("topol::topol-ban spriteszam > MAXSPRITE!: ");
         }
@@ -1390,7 +1390,7 @@ void topol::loadbelso(const char* filenev) {
         internal_error("topol::topol-ban nem tudta olvasni lebego gyuruszamot!");
     }
 
-    int gyuruszam = gyuruolvszam;
+    int gyuruszam = (int)(gyuruolvszam);
     if (gyuruszam > MAXGYURU) {
         internal_error("topol::topol-ban gyuruszam > MAXGYURU!: ");
     }
@@ -1404,7 +1404,7 @@ void topol::loadbelso(const char* filenev) {
         internal_error("topol::topol-ban nem tudta olvasni lebego kerekszamot!");
     }
 
-    int kerekszam = kerekolvszam;
+    int kerekszam = (int)(kerekolvszam);
     if (kerekszam > MAXKEREK) {
         internal_error("topol::topol-ban kerekszam > MAXKEREK!: ");
     }
@@ -1430,7 +1430,7 @@ void topol::loadbelso(const char* filenev) {
             internal_error("topol::topol-ban nem tudta olvasni lebego spriteszamot!");
         }
 
-        int spriteszam = spriteolvszam;
+        int spriteszam = (int)(spriteolvszam);
         if (spriteszam > MAXSPRITE) {
             internal_error("topol::topol-ban spriteszam > MAXSPRITE!: ");
         }

--- a/anim.cpp
+++ b/anim.cpp
@@ -48,7 +48,7 @@ constexpr double FrameTimestep = 0.014;
 // Input time is milliseconds*0.182*0.0024
 // Therefore framerate is 31.2 fps?
 pic8* anim::get_frame_by_time(double time) {
-    int step = time / FrameTimestep;
+    int step = (int)(time / FrameTimestep);
     int i = step % frame_count;
     return frames[i];
 }

--- a/editor_canvas.cpp
+++ b/editor_canvas.cpp
@@ -31,13 +31,13 @@ double pixel_to_meter_y(int y) {
 // Convert in-game meter to editor canvas pixels
 int meter_to_pixel_x(double x) {
     double pixel_x = (x - CanvasTopLeft.x) * CanvasMetersToPixels;
-    return pixel_x + 0.5 + EDITOR_MENU_X;
+    return (int)(pixel_x + 0.5 + EDITOR_MENU_X);
 }
 
 // Convert in-game meter to editor canvas pixels
 int meter_to_pixel_y(double y) {
     double pixel_y = (y - CanvasTopLeft.y) * CanvasMetersToPixels;
-    return pixel_y + 0.5 + EDITOR_MENU_Y;
+    return (int)(pixel_y + 0.5 + EDITOR_MENU_Y);
 }
 
 // Convert editor canvas pixel to in-game meters
@@ -205,8 +205,8 @@ void render_line(vect2 v1, vect2 v2, bool dotted) {
 
         // Draw from x1 + 0.5 to x2 + 0.5
         // but remove the last pixel of the line to avoid double-drawing where two lines connect
-        int xstart = x1 + 0.5;
-        int xend = x2 + 0.5;
+        int xstart = (int)(x1 + 0.5);
+        int xend = (int)(x2 + 0.5);
         if (inverted) {
             xstart++;
         } else {
@@ -219,7 +219,7 @@ void render_line(vect2 v1, vect2 v2, bool dotted) {
             }
             // Calculate the y position and draw it if it is within the internal editor render box
             double yd = y0 + slope * x;
-            int y = yd + 0.5;
+            int y = (int)(yd + 0.5);
             if (x >= EDITOR_MENU_X && y >= EDITOR_MENU_Y && x < SCREEN_WIDTH && y < SCREEN_HEIGHT) {
                 // Invert the palette ID
                 unsigned char pal_index = BufferMain->gpixel(x, y);
@@ -254,8 +254,8 @@ void render_line(vect2 v1, vect2 v2, bool dotted) {
 
         // Draw from y1 + 0.5 to y2 + 0.5
         // but remove the last pixel of the line to avoid double-drawing where two lines connect
-        int ystart = y1 + 0.5;
-        int yend = y2 + 0.5;
+        int ystart = (int)(y1 + 0.5);
+        int yend = (int)(y2 + 0.5);
         if (inverted) {
             ystart++;
         } else {
@@ -268,7 +268,7 @@ void render_line(vect2 v1, vect2 v2, bool dotted) {
             }
             // Calculate the x position and draw it if it is within the internal editor render box
             double xd = x0 + slope * y;
-            int x = xd + 0.5;
+            int x = (int)(xd + 0.5);
             if (x >= EDITOR_MENU_X && y >= EDITOR_MENU_Y && x < SCREEN_WIDTH && y < SCREEN_HEIGHT) {
                 // Invert the palette ID
                 unsigned char pal_index = BufferMain->gpixel(x, y);

--- a/grass.cpp
+++ b/grass.cpp
@@ -51,9 +51,9 @@ static int grass_line_heightmap(gyuru* poly, int v1, int v2, int* x0, int cur, i
     }
 
     // Convert coordinates into pixel positions
-    int x1 = (r1.x - origin->x) * MetersToPixels;
+    int x1 = (int)((r1.x - origin->x) * MetersToPixels);
     double y1 = (-r1.y - origin->y) * MetersToPixels;
-    int x2 = (r2.x - origin->x) * MetersToPixels;
+    int x2 = (int)((r2.x - origin->x) * MetersToPixels);
     double y2 = (-r2.y - origin->y) * MetersToPixels;
 
     if (x1 < 0 || y1 < 0 || x2 < 0 || y2 < 0) {
@@ -67,7 +67,7 @@ static int grass_line_heightmap(gyuru* poly, int v1, int v2, int* x0, int cur, i
             internal_error("grass_line_heightmap x0 already initialised!");
         }
         *x0 = x1;
-        heightmap[0] = y1;
+        heightmap[0] = (int)(y1);
     }
 
     // Skip lines of length 0.
@@ -108,7 +108,7 @@ static int grass_line_heightmap(gyuru* poly, int v1, int v2, int* x0, int cur, i
         // With:
         // t = (x - x1) / (x2 - x1)
         double y = y1 + (y2 - y1) * ((double)x - x1) / (x2 - x1);
-        heightmap[x - *x0] = y;
+        heightmap[x - *x0] = (int)(y);
         cur = x;
     }
     return cur;

--- a/pic8.cpp
+++ b/pic8.cpp
@@ -709,7 +709,7 @@ void blit_scale8(pic8* dest, pic8* source, int x1, int y1, int x2, int y2) {
         double sy = (y + 0.5) * s_per_d_y;
         for (int x = 0; x < xsd; x++) {
             double sx = (x + 0.5) * s_per_d_x;
-            unsigned char c = source->gpixel(sx, sy);
+            unsigned char c = source->gpixel((int)(sx), (int)(sy));
             dest->ppixel(x1 + x, y1 + y, c);
         }
     }


### PR DESCRIPTION
This gets rid of about 70 warnings, which is slightly over half of them.

The other conversion warnings require a bit more thinking so I didn't do them in this PR