### PR TITLE
refactor(gyuru): drop get_vertex_count

### DIFF
--- a/EDITTOOL.CPP
+++ b/EDITTOOL.CPP
@@ -359,7 +359,7 @@ void t_create_vert_nyomva(int mx, int my) {
 
     if (Pgy) {
         // Most fogunk letenni uj pontot:
-        if (Pgy->get_vertex_count() >= MAX_VERTICES) {
+        if (Pgy->vertex_count >= MAX_VERTICES) {
             char tmp[100];
             sprintf(tmp, "already reached the maximum number of vertices in this level! (%d)",
                     MAX_VERTICES);
@@ -410,7 +410,7 @@ void t_create_vert_esc(void) {
     alaphelp();
     if (Pgy) {
         // Pgy igaz, tehat egy pont meg van fogva, amit torlunk:
-        if (Pgy->get_vertex_count() <= 3) {
+        if (Pgy->vertex_count <= 3) {
             // Egesz poligont toroljuk:
             // Eloszor egy kis ellenorzes:
             int gyuruszam = 0;

--- a/polygon.cpp
+++ b/polygon.cpp
@@ -245,8 +245,6 @@ bool polygon::intersection_point(vect2 r1, vect2 v1, int skip_v, vect2* intersec
     return false;
 }
 
-int polygon::get_vertex_count() { return vertex_count; }
-
 // Load a polygon from a file
 polygon::polygon(FILE* h, int version) {
     vertex_count = 0;

--- a/polygon.h
+++ b/polygon.h
@@ -19,7 +19,6 @@ class polygon {
     polygon(FILE* h, int version);
     ~polygon();
 
-    int get_vertex_count();
     void save(FILE* h, topol* lev);
     void set_vertex(int v, double x, double y);
     void render_one_line(int v, bool forward, bool dotted);


### PR DESCRIPTION
I'm going to move this commit into its own PR so we can discuss what to do

Currently the polygon/gyuru class has a public var "vertex_count" and a getter "get_vertex_count()" that at the moment both do the same thing.

There are 22 external references to vertex_count, of which 20 directly access polygon->vertex_count and only 2 access polygon->get_vertex_count(). The polygon class is also such a fundamental type that it is unlikely to be significantly modified. In addition, as long as we have non-encapsulated direct access to the "vertices" var then you cannot even have a meaningful encapsulation with get_vertex_count().

The best thing is to simplify to make all 22 references directly access vertex_count. If we want to later add encapsulation to the polygon/gyuru class, it will be a significant refactoring and we can do it at that point when we need it.