### PR TITLE
fix(JATEKOS): avoid crash when creating new state.dat

### DIFF
--- a/JATEKOS.CPP
+++ b/JATEKOS.CPP
@@ -10,7 +10,7 @@ static int Maxnevhossz = 8; // Ez kisebb kell hogy legyen MAX_PLAYERNAME_LENGTH-
 
 // Siker eseten igazzal ter vissza:
 static int bevesznevet(char* nev, int visszater) {
-    menu_pic szovlist;
+    menu_pic szovlist(false);
 
     int i = 0;
     empty_keypress_buffer();


### PR DESCRIPTION
The error "menu_pic::render_intro_anim should not center vertically!" would show when no state.dat was present, because the new player code was accidentally creating a menu that centered.