### PR TITLE
fix(RECORDER): fix loading replays on macOS / Linux

### DIFF
--- a/MAINMENU.CPP
+++ b/MAINMENU.CPP
@@ -206,7 +206,7 @@ void replay(void) {
                 // 0 param azt jelenti, hogy nem resource filebol olvas:
                 MenuPalette->set();
                 kiirloading();
-                long belyeg = loadrecek(tmp, 0);
+                int belyeg = loadrecek(tmp, 0);
                 if (access_level_file(Prec1->palyanev) != 0) {
                     int c = menu_dialog("Cannot find the lev file that corresponds",
                                         "to the record file!", tmp, Prec1->palyanev);
@@ -236,7 +236,7 @@ void replay(void) {
             strcpy(tmp, NavEntriesLeft[kurrens]);
             strcat(tmp, ".REC");
             kiirloading();
-            long belyeg = loadrecek(tmp, 0);
+            int belyeg = loadrecek(tmp, 0);
             if (CtrlAltPressed) {
                 // loadrecek beallitotta Multirec-et.
                 int ido = Prec1->betoltve;
@@ -287,7 +287,7 @@ static void demo(void) {
         elozodemo = demo;
 
         kiirloading();
-        long belyeg = loadrecek(demonevek[demo], 1);
+        int belyeg = loadrecek(demonevek[demo], 1);
         if (access_level_file(Prec1->palyanev) != 0) {
             internal_error("783654");
         }

--- a/PLAY.CPP
+++ b/PLAY.CPP
@@ -185,7 +185,7 @@ static void konvback(char* text) {
     }
 } */
 
-void saveplay(long belyeg) {
+void saveplay(int belyeg) {
     // Korny->pabc_saveplay->write( Korny->picbuffer, 20, 2*SM, "To exit press ESC!" );
     // Korny->pabc_saveplay->write( Korny->picbuffer, 20, 5*SM, "Please enter filename:" );
     // lassufizre( Korny->picbuffer, Korny->pal_saveplay );

--- a/RECORDER.CPP
+++ b/RECORDER.CPP
@@ -50,16 +50,16 @@ recorder::recorder(void) {
     tag = 0;
 
     // Ellenorzes:
-    long hossz = sizeof(float);
+    int hossz = sizeof(float);
     if (hossz != 4) {
         internal_error("float hossz != 4!");
     }
-    hossz = long(Darabszam) * sizeof(float);
+    hossz = Darabszam * sizeof(float);
     if (hossz > 64000l) {
         internal_error("Darabszam*sizeof( float )!");
     }
 
-    hossz = long(Hangdarabszam) * sizeof(egyhang);
+    hossz = Hangdarabszam * sizeof(egyhang);
     if (hossz > 64000l) {
         internal_error("Hangdarabszam*sizeof( egyhang )!");
     }
@@ -499,7 +499,7 @@ static void olvhiba(const char* nev) {
 
 // demo eseten resource file-bol nyit:
 // belyeg-et adja vissza, vagy 0-at:
-long recorder::load(const char* nev, FILE* h, int demo) {
+int recorder::load(const char* nev, FILE* h, int demo) {
     int megvoltnyitva = 0;
     if (h) {
         megvoltnyitva = 1;
@@ -533,7 +533,7 @@ long recorder::load(const char* nev, FILE* h, int demo) {
         internal_error("recorder load-ban betoltve > Darabszam!");
     }
 
-    long verzio = 0;
+    int verzio = 0;
     if (fread(&verzio, 1, 4, h) != 4) {
         internal_error("Nem sikerult olvasni recorded file-bol!: ", nev);
     }
@@ -556,7 +556,7 @@ long recorder::load(const char* nev, FILE* h, int demo) {
         internal_error("Nem sikerult olvasni recorded file-bol!: ", nev);
     }
 
-    long belyeg = 0;
+    int belyeg = 0;
     if (fread(&belyeg, 1, 4, h) != 4) {
         olvhiba(nev);
     }
@@ -638,7 +638,7 @@ long recorder::load(const char* nev, FILE* h, int demo) {
         olvhiba(nev);
     }
 
-    long magic = 0;
+    int magic = 0;
     if (fread(&magic, 1, 4, h) != 4) {
         olvhiba(nev);
     }
@@ -680,7 +680,7 @@ static void irhiba(const char* nev) {
     internal_error("Nem sikerult irni recorded file-ba!: ", nev);
 }
 
-void recorder::save(const char* nev, FILE* h, long belyeg, int tag_p) {
+void recorder::save(const char* nev, FILE* h, int belyeg, int tag_p) {
     tag = tag_p;
 
     int megvoltnyitva = 0;
@@ -708,7 +708,7 @@ void recorder::save(const char* nev, FILE* h, long belyeg, int tag_p) {
 
     // Verzio csak 1.2-tol kezdodoen jon bele:
     // Elozoleg itt level volt, ami biztos hogy kisebb volt 120-nal:
-    long verzio = 131;
+    int verzio = 131;
     if (fwrite(&verzio, 1, 4, h) != 4) {
         irhiba(nev);
     }
@@ -790,7 +790,7 @@ void recorder::save(const char* nev, FILE* h, long belyeg, int tag_p) {
         irhiba(nev);
     }
 
-    long magic = MAGICNUMBER;
+    int magic = MAGICNUMBER;
     if (fwrite(&magic, 1, 4, h) != 4) {
         irhiba(nev);
     }
@@ -801,7 +801,7 @@ void recorder::save(const char* nev, FILE* h, long belyeg, int tag_p) {
 }
 
 // demo eseten resource file-bol nyit:
-long loadrecek(const char* nev, int demo) {
+int loadrecek(const char* nev, int demo) {
     // Eloszor megvizsgaljuk, hogy multirec vagy nem:
     FILE* h;
     if (demo) {
@@ -822,7 +822,7 @@ long loadrecek(const char* nev, int demo) {
         internal_error("Nem sikerult olvasni recorded file-bol!: ", nev);
     }
 
-    long verzio = 0;
+    int verzio = 0;
     if (fread(&verzio, 1, 4, h) != 4) {
         internal_error("Nem sikerult olvasni recorded file-bol!: ", nev);
     }
@@ -847,7 +847,7 @@ long loadrecek(const char* nev, int demo) {
     }
 
     // Most jon tenyleges beolvasas:
-    long belyeg = 0;
+    int belyeg = 0;
     if (Multirec) {
         FILE* h;
         if (demo) {
@@ -880,7 +880,7 @@ long loadrecek(const char* nev, int demo) {
 }
 
 // belyeg-et adja vissza, vagy 0-at:
-void saverecek(const char* nev, long belyeg, int tag) {
+void saverecek(const char* nev, int belyeg, int tag) {
     if (Multirec) {
         char tmpnev[40];
         sprintf(tmpnev, "rec/%s", nev);

--- a/RECORDER.H
+++ b/RECORDER.H
@@ -20,14 +20,14 @@ struct egyhang {
     float hangero;
 };
 
-long loadrecek(const char* nev, int demo);
-void saverecek(const char* nev, long belyeg, int tag);
+int loadrecek(const char* nev, int demo);
+void saverecek(const char* nev, int belyeg, int tag);
 
 class recorder {
     // demo eseten resource file-bol nyit:
     // belyeg-et adja vissza, vagy 0-at:
-    friend long loadrecek(const char* nev, int demo);
-    friend void saverecek(const char* nev, long belyeg, int tag);
+    friend int loadrecek(const char* nev, int demo);
+    friend void saverecek(const char* nev, int belyeg, int tag);
     friend void replay(void); // Hogy betolthoz hozzaferjen
 
     float *pk1rx, *pk1ry;
@@ -38,12 +38,12 @@ class recorder {
     unsigned char *pfrekvencia, *psurlero;
     unsigned char* pgazhatra;
 
-    long betoltve;
+    int betoltve;
     int ucsokiadva;
 
     egyhang* phangok;
-    long hangbetoltve;
-    long hangkov;
+    int hangbetoltve;
+    int hangkov;
 
     vect2 ucso_r;
     double ucsot, legkozt;
@@ -52,8 +52,8 @@ class recorder {
     int tag;
     // demo eseten resource file-bol nyit:
     // belyeg-et adja vissza, vagy 0-at:
-    long load(const char* nev, FILE* h, int demo);
-    void save(const char* nev, FILE* h, long belyeg, int tag);
+    int load(const char* nev, FILE* h, int demo);
+    void save(const char* nev, FILE* h, int belyeg, int tag);
 
   public:
     char palyanev[16];


### PR DESCRIPTION
commit c577cd20149 changed `level::level_id` from `long` to `int`.  On Windows `long` is 32-bit, on macOS / 64-bit Linux it's 64-bit.

This mismatch caused the following condition to fail for some replays:

    long belyeg = loadrecek(tmp, 0);

    if (Ptop->level_id != belyeg) {
        int c = menu_dialog("The level file has changed since the",
                            "saving of the record file!", tmp, Prec1->palyanev);

`level_id` would be converted to a `long` before being compared to `belyeg`, this is a signed type, so would be sign extended to 64-bit.  If the `level_id` had the top bit set, this would mean the top 32 bits were all 1s, so would fail the comparison with `belyeg`.

Replace all uses of `long` in RECORDER with `int`.