### PR TITLE
fix(KIRAJ320): ensure camera is centered with qframe shown

### DIFF
--- a/KIRAJ320.CPP
+++ b/KIRAJ320.CPP
@@ -89,7 +89,11 @@ void beallitmereteket(int splitscreen) {
     Hatary2 = Cysize - 3.0;
 
     // Motoros kepernyo mely reszen helyezkedik el:
-    Mo_bal = (SCREEN_WIDTH / MetersToPixels) * (EolSettings->center_camera ? 0.50 : 0.15);
+    if (EolSettings->center_camera) {
+        Mo_bal = (Cxsize / MetersToPixels) * 0.50;
+    } else {
+        Mo_bal = (SCREEN_WIDTH / MetersToPixels) * 0.15;
+    }
     Mo_dx = Cxsize / MetersToPixels - 2.0 * Mo_bal;
     Mo_y = Cysize / MetersToPixels / 2.0;
 


### PR DESCRIPTION
Using -/+ keys to decrease/increase the screen size would cause the camera (or rather bike), to not stay centered. This is because the calculation was based on `SCREEN_WIDTH` (total screen width), not Cxsize (the actual drawn screen width).

If center camera is not enabled, the calculation is based on `SCREEN_WIDTH` still. This matches the behaviour of Elma 1.2.