### PR TITLE
fix(teljes): Revert change to set_spacing call

### DIFF
--- a/TELJES.CPP
+++ b/TELJES.CPP
@@ -86,9 +86,9 @@ void menu_intro(void) {
 
     // Load globals
     Pabc1 = new abc8("kisbetu1.abc"); // "small letter 1"
-    Pabc1->set_spacing(true);
+    Pabc1->set_spacing(1);
     Pabc2 = new abc8("kisbetu2.abc"); // "small letter 2"
-    Pabc2->set_spacing(true);
+    Pabc2->set_spacing(1);
 
     Rec1 = new recorder;
     Rec2 = new recorder;


### PR DESCRIPTION
Commit 6c5b469 inadvertently changed this to pass `true` as parameter when the function takes an int