### PR TITLE
fix(ECSET): fix grass padding broken by loop variable shadowing param…

### DIFF
--- a/ECSET.CPP
+++ b/ECSET.CPP
@@ -955,14 +955,14 @@ void canvas::draw_qgrass_texture(grass* grass, int qupdown_index, int x, int y, 
     // Add 20 pixels of height to grass
     int grass_height_padding = QGRASS_EXTRA_HEIGHT * EolSettings->zoom();
     if (felso) {
-        for (int y = 0; y < grass_height_padding; y++) {
+        for (int i = 0; i < grass_height_padding; i++) {
             draw_pixels((unsigned char*)(pixelek_t)(texture_index + 10), distance, x, x + width - 1,
-                        y + height + y, clipping);
+                        y + height + i, clipping);
         }
     } else {
-        for (int y = 0; y < grass_height_padding; y++) {
+        for (int i = 0; i < grass_height_padding; i++) {
             draw_pixels((unsigned char*)(pixelek_t)(texture_index + 10), distance, x, x + width - 1,
-                        y - 1 - y, clipping);
+                        y - 1 - i, clipping);
         }
     }
 }


### PR DESCRIPTION
…eter

db890901900e80e9c9eef4f9ecde5b5b2ed4826b renamed the `yo` parameter to `y`, but the for-loop also used `y` as its iterator. This caused the loop variable to shadow the parameter, so `yo + ysize + y` became `y + height + y` where both `y` refer to the loop variable (always producing 2*loop_y + height instead of param_y + height + loop_y). The bottom case `yo - 1 - y` became `y - 1 - y` which always evaluates to -1.

Rename the loop variables to `i` to avoid the shadowing.