### PR TITLE
refactor(LEJATSZO): drop checks for `replay_filename` length

### DIFF
--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -964,12 +964,7 @@ long lejatszo_r(const char* filenev, int showkepmarad) {
 
 // Sets the path of VideoOutputDirectory to "./renders/{replay_stem}/"
 static void setup_render_directory(const char* replay_filename) {
-    std::string safe_name(replay_filename);
-    if (safe_name.length() > MAX_FILENAME_LEN + 4) {
-        safe_name.resize(MAX_FILENAME_LEN + 4);
-    }
-
-    std::filesystem::path p(safe_name);
+    std::filesystem::path p(replay_filename);
     std::string stem = p.stem().string();
     std::filesystem::path out_dir = std::filesystem::path("renders") / stem;
     std::error_code ec;


### PR DESCRIPTION
This should have already been validated by the replay menu, and the files being written to disk are .pcx for the replay render feature, so do not need any additonal restrictions as they are not used in game.