### PR TITLE
fix(menu_main): remove duplicate replay dispatch in menu_replay()

### DIFF
--- a/menu_main.cpp
+++ b/menu_main.cpp
@@ -167,20 +167,6 @@ static void menu_replay() {
         if (choice < 0) {
             return;
         }
-
-        if (choice == 0) {
-            replay_randomizer(replay_names);
-        } else {
-            const std::string& replay_name = replay_names[choice - 1];
-            // Play a rec file:
-            if (is_key_down(DIK_F1)) {
-                replay_render(replay_name);
-            } else if (is_key_down(DIK_LCONTROL) && is_key_down(DIK_LMENU)) {
-                replay_time(replay_name);
-            } else {
-                replay_play(replay_name);
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Regression from b06d410d which converted menu_replay from menu_nav_old to menu_nav. menu_nav_old::navigate() just returned the choice index, so the caller dispatched afterwards. menu_nav::navigate() invokes the row callback before returning. The conversion added callbacks but kept the outer dispatch code, causing every replay selection to be dispatched twice — with the second dispatch picking the wrong file because replay_names was no longer sorted to match the nav order.