### PR TITLE
fix(vect2): fix regression during translation

### DIFF
--- a/vect2.cpp
+++ b/vect2.cpp
@@ -81,7 +81,7 @@ vect2 intersection(const vect2& r1, vect2 v1, vect2 r2, vect2 v2) {
 double point_segment_distance(const vect2& point_r, const vect2& segment_r,
                               const vect2& segment_v) {
     vect2 rr = point_r - segment_r;
-    double scalar = segment_r * rr;
+    double scalar = segment_v * rr;
     if (scalar <= 0) {
         // Distance to the first point.
         return rr.length();


### PR DESCRIPTION
commit 86a4347bd0ba "translate(VEKT2): public interface", accidentally used `segment_r` for `vsz` instead of `segment_v`.

    -double pontszakasztav(vekt2 rpont, vekt2 rsz, vekt2 vsz) {
    -    vekt2 rr = rpont - rsz;
    -    double skalered = vsz * rr;
    +double point_segment_distance(vekt2 point_r, vekt2 segment_r, vekt2 segment_v) {
    +    vekt2 rr = point_r - segment_r;
    +    double skalered = segment_r * rr;

closes #336 