### PR TITLE
Group menu options

### DIFF
--- a/menu_options.cpp
+++ b/menu_options.cpp
@@ -3,17 +3,13 @@
 #include "fs_utils.h"
 #include "JATEKOS.H"
 #include "level_load.h"
-#include "M_PIC.H"
 #include "menu_controls.h"
 #include "menu_nav.h"
 #include "menu_pic.h"
-#include "platform_utils.h"
 #include "state.h"
-#include <algorithm>
 #include <cstring>
 #include <cmath>
 #include <format>
-#include <vector>
 
 void menu_help() {
     menu_pic menu;


### PR DESCRIPTION
This is just blindly copying what @GauChoob commented in #368

Put replay recording fps into an "Other" menu.

Closes #368