### PR TITLE
Save screenshot as bmp instead of pcx

### DIFF
--- a/EDITUJ.CPP
+++ b/EDITUJ.CPP
@@ -750,24 +750,7 @@ void editor() {
                 }
 
                 if (c == 'i') {
-                    // Kiirjuk kepet:
-                    int i = 0;
-                    while (1) {
-                        char filenev[20];
-                        if (i < 10) {
-                            sprintf(filenev, "snap0%d.pcx", i);
-                        } else {
-                            sprintf(filenev, "snap%d.pcx", i);
-                        }
-                        if (access(filenev, 0) != 0) {
-                            // Ez a nev nem foglalt:
-                            // ppic->vertical_flip();
-                            BufferMain->save(filenev, Pal_editor_byteok);
-                            // ppic->vertical_flip();
-                            break;
-                        }
-                        i++;
-                    }
+                    platform_save_screenshot();
                 }
             }
             // Csak debuggolashoz kellettek:

--- a/KIRAJ320.CPP
+++ b/KIRAJ320.CPP
@@ -17,6 +17,8 @@
 #include "main.h"
 #include "object.h"
 #include "pic8.h"
+#include "platform/implementation.h"
+#include "platform/utils.h"
 #include "physics_init.h"
 #include "renderer/object_overlay.h"
 #include "timer.h"
@@ -392,17 +394,7 @@ static void handle_screenshot(pic8* pic) {
 
     if (Legkozment) {
         Legkozment = 0;
-        int i = 0;
-        while (true) {
-            std::string filename = std::format("snp{:05}.pcx", i);
-            if (!std::filesystem::exists(filename)) {
-                pic->vertical_flip();
-                pic->save(filename.c_str(), Lgr->palette_data);
-                pic->vertical_flip();
-                break;
-            }
-            i++;
-        }
+        platform_save_screenshot();
     }
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -50,6 +50,8 @@
 * When choosing foreground or background texture, internal editor will preview the image
 * Unlimited amount of files supported in lev/ and rec/ folders
 * Mask previews are no longer horizontally truncated in the internal editor
+* Screenshots are now saved into the screenshots folder with a timestamp-name instead of root snp00001
+* Screenshots are now saved as bmp instead of pcx
 
 ## Minor Bug Fixes
 * Enforce lowercase LGR filenames to fix loading issues on case-sensitive filesystems

--- a/include/platform/implementation.h
+++ b/include/platform/implementation.h
@@ -70,5 +70,6 @@ std::pair<int, int> platform_get_desktop_resolution();
 void platform_resize_window(int width, int height);
 void platform_recreate_window();
 bool has_window();
+bool platform_save_screenshot();
 
 #endif

--- a/src/platform/sdl/sdl.cpp
+++ b/src/platform/sdl/sdl.cpp
@@ -12,6 +12,9 @@
 #include "pic8.h"
 #include <directinput/scancodes.h>
 #include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <format>
 #include <SDL.h>
 #include <sdl/scancodes_windows.h>
 
@@ -559,4 +562,18 @@ void init_sound() {
         internal_error("Failed to get correct audio format");
     }
     SDL_PauseAudioDevice(SDLAudioDevice, 0);
+}
+
+bool platform_save_screenshot() {
+    if (!SDLSurfacePaletted) {
+        return false;
+    }
+
+    std::filesystem::create_directories("screenshots");
+
+    auto now = std::chrono::system_clock::now();
+    auto time = std::chrono::floor<std::chrono::seconds>(now);
+    std::string filename = std::format("screenshots/{:%Y-%m-%d_%H-%M-%S}.bmp", time);
+
+    return SDL_SaveBMP(SDLSurfacePaletted, filename.c_str()) == 0;
 }

--- a/src/platform/sdl/sdl.cpp
+++ b/src/platform/sdl/sdl.cpp
@@ -357,10 +357,9 @@ palette::~palette() { delete[] (SDL_Color*)data; }
 
 void palette::set() {
     CurrentPalette = this;
+    SDL_SetPaletteColors(SDLSurfacePaletted->format->palette, (const SDL_Color*)data, 0, 256);
     if (EolSettings->renderer() == RendererType::OpenGL) {
         gl_update_palette(data);
-    } else {
-        SDL_SetPaletteColors(SDLSurfacePaletted->format->palette, (const SDL_Color*)data, 0, 256);
     }
 }
 


### PR DESCRIPTION
Implements point 2 and 3 of https://github.com/elmadev/elma-classic/issues/55