### PR TITLE
fix(build): set clang-format-19 in alternatives

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-format-19 libgl1-mesa-dev
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-19 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-19
+          clang-format --version
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
When clang-format-19 is installed, it is installed as /usr/bin/clang-format-19, so it was never actually being used.