### PR TITLE
feat(qopen): allow building for SHAREWARE resources

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,10 @@ if get_option('profile_performance') == true
     add_project_arguments('-DPROFILE_PERFORMANCE', language: 'cpp')
 endif
 
+if get_option('shareware') == true
+    add_project_arguments('-DELMA_SHAREWARE', language: 'cpp')
+endif
+
 elma_sources = files(
     'abc8.cpp',
     'physics_init.cpp',

--- a/meson.options
+++ b/meson.options
@@ -1,3 +1,5 @@
 option('profile_performance', type : 'boolean', value : false, description: 'enable performance timing checks')
 
 option('static_sdl', type : 'boolean', value : false, description: 'link SDL statically')
+
+option('shareware', type : 'boolean', value : false, description: 'shareware elma resources')

--- a/qopen.cpp
+++ b/qopen.cpp
@@ -6,8 +6,13 @@
 struct res_file {
     char filename[16];
     // In Shareware the order of these two fields is reversed.
+    #ifdef ELMA_SHAREWARE
+    int offset;
+    int length;
+    #else
     int length;
     int offset;
+    #endif
 };
 
 constexpr char RES_FILENAME[] = "elma.res";
@@ -23,7 +28,11 @@ static int FileCount = 0;
 static void decrypt() {
     short a = 23;
     // In Shareware, b is 9882
+    #ifdef ELMA_SHAREWARE
+    short b = 9882;
+    #else
     short b = 9982;
+    #endif
     short c = 3391;
 
     if (!ResFiles) {


### PR DESCRIPTION
adds compile option that lets you build for the SHAREWARE version of elma resources.