### PR TITLE
One Wheel Cripple

### DIFF
--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -2,6 +2,7 @@
 #include "EDITUJ.H"
 #include "eol/console.h"
 #include "eol/eol.h"
+#include "eol/status_messages.h"
 #include "eol_settings.h"
 #include "flagtag.h"
 #include "sound_engine.h"
@@ -675,6 +676,16 @@ long lejatszo(const char* filenev, CameraMode cameramode) {
         if (was_game_key_just_pressed(DIK_F5)) {
             EolClient->set_table(TableType::PlayersOnline);
         }
+        if (is_key_down(DIK_LSHIFT) && was_key_just_pressed(DIK_F8)) {
+            EolSettings->set_show_last_apple_time(!EolSettings->show_last_apple_time());
+            StatusMessages->add(EolSettings->show_last_apple_time() ? "last apple time shown"
+                                                                    : "last apple time hidden");
+        }
+        if (is_key_down(DIK_LSHIFT) && was_key_just_pressed(DIK_F11)) {
+            EolSettings->set_show_one_wheel_status(!EolSettings->show_one_wheel_status());
+            StatusMessages->add(EolSettings->show_one_wheel_status() ? "one-wheel status shown"
+                                                                     : "one-wheel status hidden");
+        }
 
         // Vizsgalat kilepesre:
         if (!console_was_active &&
@@ -1049,6 +1060,16 @@ long lejatszo_r(const char* filenev, int showkepmarad) {
         // Snap nyomas elintezese:
         if (was_game_key_just_pressed(State->key_screenshot)) {
             Legkozment = 1;
+        }
+        if (is_key_down(DIK_LSHIFT) && was_key_just_pressed(DIK_F8)) {
+            EolSettings->set_show_last_apple_time(!EolSettings->show_last_apple_time());
+            StatusMessages->add(EolSettings->show_last_apple_time() ? "last apple time shown"
+                                                                    : "last apple time hidden");
+        }
+        if (is_key_down(DIK_LSHIFT) && was_key_just_pressed(DIK_F11)) {
+            EolSettings->set_show_one_wheel_status(!EolSettings->show_one_wheel_status());
+            StatusMessages->add(EolSettings->show_one_wheel_status() ? "one-wheel status shown"
+                                                                     : "one-wheel status hidden");
         }
 
         // Vizsgalat kilepesre:

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -656,7 +656,7 @@ long lejatszo(const char* filenev, CameraMode cameramode) {
         }
 
         render_game(eddig, &valt1, &valt2, Viewtime1.viewkinplay, Viewtime1.timekinplay,
-                    Viewtime2.viewkinplay, Viewtime2.timekinplay, current_camera);
+                    Viewtime2.viewkinplay, Viewtime2.timekinplay, current_camera, false);
 
         // Egy par kozos toggle:
         // Plusz elintezes:
@@ -1032,7 +1032,7 @@ long lejatszo_r(const char* filenev, int showkepmarad) {
         }
 
         render_game(eddig, &valt1, &valt2, Viewtime1.viewkinreplay, Viewtime1.timekinreplay,
-                    Viewtime2.viewkinreplay, Viewtime2.timekinreplay, current_camera);
+                    Viewtime2.viewkinreplay, Viewtime2.timekinreplay, current_camera, true);
 
         // Egy par kozos toggle:
         // Plusz elintezes:
@@ -1153,7 +1153,7 @@ void render_replay(const char* level_filename) {
         }
 
         render_game(eddig, &valt1, &valt2, Viewtime1.viewkinreplay, Viewtime1.timekinreplay,
-                    Viewtime2.viewkinreplay, Viewtime2.timekinreplay, current_camera);
+                    Viewtime2.viewkinreplay, Viewtime2.timekinreplay, current_camera, true);
 
         VideoFrameIndex++;
     }

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -286,6 +286,11 @@ static void belsoresz(motorst* pmot, player_keys* popciok, valtozok* pvalt, reco
         }
         prec->store_event(eddig, wavazonosito, hangero, objszam);
     }
+
+    if (EolSettings->cripple_one_wheel() && pmot->one_wheel_failed) {
+        *pmeghalt = 1;
+        return;
+    }
 }
 
 static void toggleresz(player_keys* popciok, valtozok* pvalt, int* pviewkin, int* ptimekin,

--- a/eol_settings.cpp
+++ b/eol_settings.cpp
@@ -229,6 +229,10 @@ void eol_settings::set_cripple_one_turn(bool b) {
     }
 }
 
+void eol_settings::set_cripple_one_wheel(bool b) { cripple_one_wheel_ = b; }
+
+void eol_settings::set_show_one_wheel_status(bool b) { show_one_wheel_status_ = b; }
+
 void eol_settings::set_hostname(std::string hostname) { hostname_ = std::move(hostname); }
 
 void eol_settings::set_tcp_port(int p) { tcp_port_ = p; }
@@ -382,6 +386,8 @@ void from_json(const json& j, FullscreenMode& f) {
     JSON_FIELD(cripple_no_volt)                                                                    \
     JSON_FIELD(cripple_one_turn)                                                                   \
     JSON_FIELD(cripple_drunk)                                                                      \
+    JSON_FIELD(cripple_one_wheel)                                                                  \
+    JSON_FIELD(show_one_wheel_status)                                                              \
     JSON_FIELD(hostname)                                                                           \
     JSON_FIELD(tcp_port)                                                                           \
     JSON_FIELD(nick)                                                                               \

--- a/eol_settings.h
+++ b/eol_settings.h
@@ -127,6 +127,8 @@ class eol_settings {
     Default<bool> cripple_no_volt_{false};
     Default<bool> cripple_one_turn_{false};
     Default<bool> cripple_drunk_{false};
+    Default<bool> cripple_one_wheel_{false};
+    Default<bool> show_one_wheel_status_{false};
     Default<std::string> hostname_{"eol.elma.online"};
     Default<int> tcp_port_{DEFAULT_TCP_PORT};
     Default<std::string> nick_{""};
@@ -189,6 +191,8 @@ class eol_settings {
     DECLARE_FIELD_FUNCS(cripple_no_volt);
     DECLARE_FIELD_FUNCS(cripple_one_turn);
     DECLARE_FIELD_FUNCS(cripple_drunk);
+    DECLARE_FIELD_FUNCS(cripple_one_wheel);
+    DECLARE_FIELD_FUNCS(show_one_wheel_status);
     DECLARE_FIELD_FUNCS(hostname);
     DECLARE_FIELD_FUNCS(tcp_port);
     DECLARE_FIELD_FUNCS(nick);

--- a/include/renderer/render.h
+++ b/include/renderer/render.h
@@ -17,6 +17,7 @@ void increase_view_size();
 void decrease_view_size();
 
 void render_game(double time, valtozok* metadata1, valtozok* metadata2, bool show_minimap1,
-                 bool show_timer1, bool show_minimap2, bool show_timer2, camera& current_camera);
+                 bool show_timer1, bool show_minimap2, bool show_timer2, camera& current_camera,
+                 bool is_replay);
 
 #endif

--- a/physics_forces.cpp
+++ b/physics_forces.cpp
@@ -8,9 +8,12 @@
 #include "physics_init.h"
 #include "physics_move.h"
 #include "recorder.h"
+#include "timer.h"
 #include "util/util.h"
 #include <algorithm>
 #include <cmath>
+
+constexpr double ONE_WHEEL_GRACE = 10.0 / TimeToCentiseconds;
 
 static double MaxFrictionVolume = 0.0;
 
@@ -317,6 +320,10 @@ void simulate_bike_physics(motorst* mot, double time, double dt, bool gas, bool 
             mot->bike.angular_velocity - prevolt_angular_velocity;
         vect2 body_spring_perp = rotate_90deg(mot->body_r - mot->bike.r);
         mot->body_v = mot->body_v + body_spring_perp * bike_relative_angular_velocity;
+    }
+
+    if (mot->left_wheel.touching_edge && mot->right_wheel.touching_edge && time > ONE_WHEEL_GRACE) {
+        mot->one_wheel_failed = true;
     }
 
     // Update the body position and bike/wheel positions based on gravity

--- a/physics_init.cpp
+++ b/physics_init.cpp
@@ -46,6 +46,7 @@ void init_motor(motorst* motor) {
     motor->flipped_camera = 0;
     motor->gravity_direction = MotorGravity::Down;
     motor->prev_brake = false;
+    motor->one_wheel_failed = false;
 
     motor->bike.rotation = 0.0;
     motor->bike.angular_velocity = 0.0;
@@ -64,6 +65,7 @@ void init_motor(motorst* motor) {
     motor->left_wheel.inertia = 0.32;
     motor->left_wheel.r = vect2(1.9, 3.0);
     motor->left_wheel.v = vect2(0, 0);
+    motor->left_wheel.touching_edge = false;
 
     motor->right_wheel.rotation = 0.0;
     motor->right_wheel.angular_velocity = 0.0;
@@ -72,6 +74,7 @@ void init_motor(motorst* motor) {
     motor->right_wheel.inertia = 0.32;
     motor->right_wheel.r = vect2(3.6, 3.0);
     motor->right_wheel.v = vect2(0, 0);
+    motor->right_wheel.touching_edge = false;
 
     motor->body_r = vect2(2.75, 4.04);
     motor->body_v = vect2(0.0, 0.0);

--- a/physics_init.h
+++ b/physics_init.h
@@ -44,6 +44,7 @@ struct rigidbody {
     double inertia; // Moment of inertia
     vect2 r;
     vect2 v;
+    bool touching_edge; // true if wheel is touching polygon edge
 };
 
 struct motorst {
@@ -61,6 +62,8 @@ struct motorst {
     int apple_count;
     int last_apple_time;
     int apple_bug_count;
+
+    bool one_wheel_failed;
 
     bool prev_brake;
     double left_wheel_brake_rotation;

--- a/physics_move.cpp
+++ b/physics_move.cpp
@@ -88,6 +88,7 @@ void rigidbody_movement(rigidbody* rb, vect2 force, double torque, double dt, bo
     // Get up to two points of collision between wheel and polygons
     if (do_collision) {
         anchor_point_count = get_two_anchor_points(rb->r, rb->radius, &point1, &point2);
+        rb->touching_edge = (bool)anchor_point_count;
     }
 
     // Move the wheel out of the ground

--- a/src/eol/console.cpp
+++ b/src/eol/console.cpp
@@ -111,6 +111,10 @@ void console::register_console_commands() {
     REGISTER_SETTINGS_BOOL(cripple_drunk);
     register_alias("drunk", "cripple_drunk");
     register_alias("dr", "cripple_drunk");
+    REGISTER_SETTINGS_BOOL(cripple_one_wheel);
+    register_alias("onewheel", "cripple_one_wheel");
+    register_alias("ow", "cripple_one_wheel");
+    REGISTER_SETTINGS_BOOL(show_one_wheel_status);
 }
 
 void console::add_line(std::string text, LineType type) {

--- a/src/menu/options.cpp
+++ b/src/menu/options.cpp
@@ -161,6 +161,8 @@ static void menu_cripples() {
         BOOL_OPTION("One Turn:", cripple_one_turn);
         BOOL_OPTION("No Volt:", cripple_no_volt);
         BOOL_OPTION("Drunk:", cripple_drunk);
+        BOOL_OPTION("One Wheel:", cripple_one_wheel);
+        BOOL_OPTION("Show One Wheel Status:", show_one_wheel_status);
 
         choice = nav.navigate();
 

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -605,7 +605,7 @@ static void render_bike(bool player1, pic8* pic, double time, vect2 bottomleft_c
 // Render the view for one player
 static void render_view(bool player1, pic8* pic, double time, motorst* mot, valtozok* metadata,
                         bool show_minimap, bool show_timer, motorst* other_mot,
-                        valtozok* other_metadata, camera& current_camera) {
+                        valtozok* other_metadata, camera& current_camera, bool is_replay) {
     // Calculate frame of reference
     vect2 bike_center = mot->bike.r;
     if (current_camera.mode == CameraMode::MapViewer) {
@@ -746,21 +746,33 @@ static void render_view(bool player1, pic8* pic, double time, motorst* mot, valt
     }
 
     // Draw the bottom-right info panel
-    if (mot->apple_count && EolSettings->show_last_apple_time()) {
-        char tmp[100];
-        sprintf(tmp, "last apple (%d)        ", mot->apple_count - mot->apple_bug_count);
-        util::text::centiseconds_to_string(mot->last_apple_time, tmp + strlen(tmp), true, true);
+    constexpr int RIGHT_MARGIN = 10;
+    constexpr int BOTTOM_MARGIN = 10;
+    constexpr int LABEL_OFFSET = 180;
+    int status_y = BOTTOM_MARGIN;
+    int value_x = GameViewWidth - RIGHT_MARGIN;
+    int label_x = GameViewWidth - LABEL_OFFSET;
 
-        constexpr int RIGHT_MARGIN = 5;
-        constexpr int BOTTOM_MARGIN = 5;
-        int x = GameViewWidth - RIGHT_MARGIN;
-        int y = BOTTOM_MARGIN;
-        SmallFont->write_right_align(pic, x, y, tmp);
+    if (EolSettings->show_one_wheel_status() && !is_replay) {
+        SmallFont->write(pic, label_x, status_y, "one wheel");
+        SmallFont->write_right_align(pic, value_x, status_y, mot->one_wheel_failed ? "no" : "yes");
+        status_y += SmallFont->line_height();
+    }
+
+    if (mot->apple_count && EolSettings->show_last_apple_time()) {
+        char label[100];
+        sprintf(label, "last apple (%d)", mot->apple_count - mot->apple_bug_count);
+        SmallFont->write(pic, label_x, status_y, label);
+
+        char time[20];
+        util::text::centiseconds_to_string(mot->last_apple_time, time, true, true);
+        SmallFont->write_right_align(pic, value_x, status_y, time);
     }
 }
 
 void render_game(double time, valtozok* metadata1, valtozok* metadata2, bool show_minimap1,
-                 bool show_timer1, bool show_minimap2, bool show_timer2, camera& current_camera) {
+                 bool show_timer1, bool show_minimap2, bool show_timer2, camera& current_camera,
+                 bool is_replay) {
     // Determine who we are going to draw (player 1, player 2 or both)
     bool draw_player1 = metadata1->showkep;
     bool draw_player2 = metadata2->showkep;
@@ -788,19 +800,19 @@ void render_game(double time, valtozok* metadata1, valtozok* metadata2, bool sho
     if (splitscreen) {
         player_view.subview(GameViewLeft, GameViewBottom1, GameViewRight, GameViewTop1, pic);
         render_view(true, &player_view, time, Motor1, metadata1, show_minimap1, show_timer1, Motor2,
-                    metadata2, current_camera);
+                    metadata2, current_camera, is_replay);
 
         player_view.subview(GameViewLeft, GameViewBottom2, GameViewRight, GameViewTop2, pic);
         render_view(false, &player_view, time, Motor2, metadata2, show_minimap2, show_timer2,
-                    Motor1, metadata1, current_camera);
+                    Motor1, metadata1, current_camera, is_replay);
     } else {
         player_view.subview(GameViewLeft, GameViewBottom1, GameViewRight, GameViewTop1, pic);
         if (draw_player1) {
             render_view(true, &player_view, time, Motor1, metadata1, show_minimap1, show_timer1,
-                        Motor2, metadata2, current_camera);
+                        Motor2, metadata2, current_camera, is_replay);
         } else {
             render_view(false, &player_view, time, Motor2, metadata2, show_minimap2, show_timer2,
-                        Motor1, metadata1, current_camera);
+                        Motor1, metadata1, current_camera, is_replay);
         }
     }
 

--- a/timer.h
+++ b/timer.h
@@ -1,6 +1,8 @@
 #ifndef TIMER_H
 #define TIMER_H
 
+#include "main.h"
+
 class pic8;
 
 constexpr double TimeToCentiseconds = 100.0 / (STOPWATCH_MULTIPLIER * 1000.0 * 0.0024);


### PR DESCRIPTION
Here's an implementation of one-wheel cripple based off of bene's old PR

- We re-use the result of the expensivish function call get_two_anchor_points() in physics_move.cpp, instead of adding extra calls to this function.
- The implementation of one-wheel is identical to current EOL, except for that fact that the check is a bit stricter under 80 FPS (it checks per physics frame instead of per render frame). This EOL implementation causes death 2.5 frames later than bene's original PR:
  - In bene's PR, you die on the frame before the wheel makes visible contact with the polygon (the wheel would make contact with the ground, but it's disallowed because you die instead)
  - In this PR, the two-wheel state is detected on the frame that the wheel makes visible contact with the polygon (1 frame later), and then you die on the next frame (2 frames later). Apple/Flower takes priority over dying here (2.5 frames later)
- We don't calculate nor show one-wheel in replays

We could move the if statements in the physics files earlier/later in the engine flow to adjust the death to be anywhere from +0 to +2.5 frames, but I figured we might as well re-implement the current behaviour