### PR TITLE
fix(ci): widen vs-version range to include 18.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,11 +137,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgl1-mesa-dev
 
-      - name: Visual Studio 17
+      - name: Visual Studio
         if: runner.os == 'windows'
         uses: microsoft/setup-msbuild@v3
         with:
-          vs-version: "[17.1,18.0)"
+          vs-version: "[17.1,19.0)"
 
       - name: Configure
         if: runner.os == 'windows'


### PR DESCRIPTION
windows-latest is vs-version 18 these days apparently.

https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners