### PR TITLE
Zoom front grass v2

### DIFF
--- a/canvas.cpp
+++ b/canvas.cpp
@@ -1446,15 +1446,70 @@ static int consecutive_front(int x1, int x2, int y, node_finder* finder) {
     return count;
 }
 
-void canvas::create_front_grass() {
-    node_finder* finder = new node_finder(this);
+void canvas::thicken_front_grass(int thickness, int x1, int x2, int y) {
+    // Skip the top row of front grass (handled in create_front_grass())
+    for (int i = y - 1; i > y - thickness; i--) {
+        // Find the starting chunk
+        canvas_chunk_node* prev_node = nullptr;
+        canvas_chunk_node* cur_node = rows_linked[i];
+        int j = rows_x1[i];
 
+#ifdef DEBUG
+        if (i < 0 || i >= pixel_height) {
+            internal_error("canvas::thicken_front_grass invalid y");
+        }
+        if (j > 10) {
+            internal_error("canvas::thicken_front_grass j > 10");
+        }
+#endif
+
+        while (x1 >= j + cur_node->width) {
+            j += cur_node->width;
+            prev_node = cur_node;
+            cur_node = cur_node->next;
+            if (!cur_node) {
+                internal_error("canvas::thicken_front_grass !cur_node!");
+            }
+        }
+
+        // Iterate one chunk at a time, converting to front grass if back grass
+        while (j <= x2) {
+            if (!cur_node) {
+                internal_error("canvas::thicken_front_grass !cur_node!");
+            }
+
+            int j_next = j + cur_node->width;
+            canvas_chunk_node* next_node = cur_node->next;
+            if (cur_node->pixels == *QgrassTextureId && cur_node->distance > 500) {
+                bool prev_can_merge = false;
+                int j1 = std::max(x1, j);
+                int j2 = std::min(x2, j_next - 1);
+                prev_node = draw_one_chunk(cur_node, *QgrassTextureId, j, j1, j2, 200, prev_node,
+                                           &prev_can_merge, Clipping::Unclipped);
+            } else {
+                prev_node = cur_node;
+            }
+            j = j_next;
+            cur_node = next_node;
+        }
+    }
+}
+
+void canvas::create_front_grass() {
     // A crutch that we use to avoid keeping proper track of our linked lists,
     // by making sure our chunks don't get merged together.
     bool alternate_distance = false;
 
+    const int thickness = (int)std::round(EolSettings->zoom());
+    const int margin = 10 * thickness;
+    if (thickness <= 0) {
+        return;
+    }
+
+    node_finder finder(this);
+
     // For each row
-    for (int i = 10; i < pixel_height - 10; i++) {
+    for (int i = margin; i < pixel_height - margin; i++) {
         canvas_chunk_node* cur_node = rows_linked[i];
         int xpos = rows_x1[i];
 
@@ -1482,18 +1537,17 @@ void canvas::create_front_grass() {
                     int x1 = xpos;
                     int x2 = xpos + cur_node->width;
                     while (x1 < x2) {
-                        int skip = consecutive_back(x1, x2, i, finder);
+                        int skip = consecutive_back(x1, x2, i, &finder);
                         x1 += skip;
-                        int count = consecutive_front(x1, x2, i, finder);
+                        int count = consecutive_front(x1, x2, i, &finder);
                         if (count > 0) {
                             // Move qgrass to front
                             alternate_distance = !alternate_distance;
-                            if (alternate_distance) {
-                                draw_pixels(cur_node->pixels, 223, x1, x1 + count - 1, i,
-                                            Clipping::Unclipped);
-                            } else {
-                                draw_pixels(cur_node->pixels, 224, x1, x1 + count - 1, i,
-                                            Clipping::Unclipped);
+                            const int distance = alternate_distance ? 223 : 224;
+                            draw_pixels(cur_node->pixels, distance, x1, x1 + count - 1, i,
+                                        Clipping::Unclipped);
+                            if (thickness > 1) {
+                                thicken_front_grass(thickness, x1, x1 + count - 1, i);
                             }
                         }
                         x1 += count;
@@ -1504,8 +1558,6 @@ void canvas::create_front_grass() {
             cur_node = next_node;
         }
     }
-    delete finder;
-    finder = nullptr;
 }
 
 void canvas::create_canvases() {

--- a/canvas.h
+++ b/canvas.h
@@ -202,6 +202,7 @@ class canvas {
     // Render
     void render_row(bool player1, int view_left, int view_right, unsigned char* dest, int y);
 
+    void thicken_front_grass(int thickness, int x1, int x2, int y);
     void create_front_grass();
 
     // Create blank canvas from Segments

--- a/changelog.txt
+++ b/changelog.txt
@@ -55,10 +55,11 @@
 * error.txt has been replaced with eol.log
 * You can select a default gravity and animation via right click when using the Create Food tool in the editor
 * You can delete polygons using the Delete Vertex tool in the editor
+* Front grass in front of the bike is properly zoomed
 
 ## Minor Bug Fixes
 * Enforce lowercase LGR filenames to fix loading issues on case-sensitive filesystems
-* Foreground grass was accidentally inefficiently calculated, causing increased load time
+* Front grass in front of the bike was accidentally inefficiently calculated, causing increased load time
 * Internal editor's Save As dialog box could cause buffer overflows
 * Internal editor's Save As would sometimes overwrite old files without giving a warning
 * Level description in internal editor is properly centered


### PR DESCRIPTION
I just completely rewrote the thicken_front_grass function so I'm closing the old PR and creating a new one.

For bene:

Even though the previous function seemed to work without issues, draw_pixels() can merge nodes together and it's hard to say definitively that there won't ever be any bugs.

Fundamentally, draw_pixels() changes our linked list and so it's difficult to keep track of our list - that's why create_front_grass() alternates between a distance of 223 and 224 to prevent modifications to the linked list. Not only is this kind of a dumb way of doing it, thicken_front_grass() cannot use this solution since it might be called twice on the same chunk of grass.

Lastly, since the linked list might be changed by draw_pixels(), using the node_finder helper class is also risky. (This doesn't apply to Balazs' usage of node_finder since that one iterates over an immutable row)

So the solution is to call draw_one_chunk() which is the child function of draw_pixels(). This allows us to keep track of modifications to the linked list inline within our function. This also has the added benefit of decreasing the number of times we need to iterate through our linked list by a factor of 2, speeding up the function.

tldr: I rewrote the function, please re-review