### PR TITLE
fix(LEJATSZO): reset `WhoDiedFirst` in single player mode

### DIFF
--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -515,7 +515,7 @@ int game_loop(const char* filename, CameraMode camera_mode) {
                     finish_time = finish_time2;
                 }
 
-                if (finish_time) {
+                if (finish_time || Single) {
                     WhoDiedFirst = 0;
                 }
                 Player1Finished = (bool)finish_time1;


### PR DESCRIPTION
Fixes seeing 'A died first' in single player mode.

Introduced in commit 01f3365de2250.