### PR TITLE
turning_data refactor part 1

### DIFF
--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -284,6 +284,7 @@ static void update_view_settings(player_keys* keys, bike_metadata* metadata, boo
 static void update_bike_turn_phase(turning_data* data, recorder* rec, double time, int flipped) {
     if (data->flipped != flipped) {
         // New flip this frame
+        data->flipped = flipped;
         data->bike_turn_time = time;
         if (rec) {
             start_wav(WavEvent::Turn, 0.99);
@@ -305,6 +306,7 @@ static void update_camera_turn_phase(turning_data* data, double time, int flippe
     double camera_flip_time = EolSettings->turn_time() + 0.15;
     if (data->flipped != flipped) {
         // New flip this frame
+        data->flipped = flipped;
         double time_since_prev_turn = time - data->camera_turn_time;
         if (camera_flip_time > 0.0 && time_since_prev_turn < camera_flip_time) {
             // If camera is mid-turn, calculate camera start time so it seamlessly continues from
@@ -327,18 +329,13 @@ static void update_graphical_metadata(motorst& mot, bike_metadata& metadata, rec
                                       double time) {
     // Update bike turn data
     update_bike_turn_phase(&metadata.bike_turning, rec, time, mot.flipped_bike);
-    update_camera_turn_phase(&metadata.bike_turning, time, mot.flipped_bike);
-    metadata.bike_turning.flipped = mot.flipped_bike;
 
     // Update camera position
     mot.flipped_camera = mot.flipped_bike;
     if (mot.gravity_direction == MotorGravity::Up) {
         mot.flipped_camera = !mot.flipped_camera;
     }
-
-    update_bike_turn_phase(&metadata.camera_turning, nullptr, time, mot.flipped_camera);
     update_camera_turn_phase(&metadata.camera_turning, time, mot.flipped_camera);
-    metadata.camera_turning.flipped = mot.flipped_camera;
 
     // Update arm position
     metadata.arm_position = std::max(0.0, 1.0 - (time - metadata.volt_time) / VoltDelay);
@@ -686,7 +683,6 @@ static void rewind_override_animations(bike_metadata* metadata, motorst* mot, re
     metadata->bike_turning.bike_turn_time = turn_time;
     metadata->bike_turning.camera_turn_time = turn_time;
     update_bike_turn_phase(&metadata->bike_turning, nullptr, time, mot->flipped_bike);
-    update_camera_turn_phase(&metadata->bike_turning, time, mot->flipped_bike);
 
     metadata->camera_turning.flipped = mot->flipped_camera;
     metadata->camera_turning.bike_turn_time = time - 1000.0;

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -292,7 +292,7 @@ static void update_view_settings(player_keys* keys, bike_metadata* metadata, boo
     }
 }
 
-static void update_turning_data(turning_data* data, recorder* rec, double time, int flipped) {
+static void update_turn_time(turning_data* data, recorder* rec, double time, int flipped) {
     if (data->flipped != flipped) {
         // New flip this frame
         data->bike_turn_time = time;
@@ -312,8 +312,9 @@ static void update_turning_data(turning_data* data, recorder* rec, double time, 
             rec->store_event(time, WavEvent::Turn, 0.99, -1);
         }
     }
+}
 
-    // Update bike turn phase
+static void update_bike_turn_phase(turning_data* data, double time, int flipped) {
     double turn_time = EolSettings->turn_time();
     if (turn_time == 0.0) {
         // Instant turn
@@ -322,9 +323,16 @@ static void update_turning_data(turning_data* data, recorder* rec, double time, 
         data->bike_turn_phase = (time - data->bike_turn_time) / turn_time;
         data->bike_turn_phase = std::clamp(data->bike_turn_phase, 0.0, 1.0);
     }
+}
 
-    // Update camera turn phase
+static void update_camera_turn_phase(turning_data* data, double time, int flipped) {
     data->camera_turn_phase = calculate_camera_phase(time - data->camera_turn_time, flipped);
+}
+
+static void update_turning_data(turning_data* data, recorder* rec, double time, int flipped) {
+    update_turn_time(data, rec, time, flipped);
+    update_bike_turn_phase(data, time, flipped);
+    update_camera_turn_phase(data, time, flipped);
 }
 
 // The only physics-relevant part of this function is turning the bike. The rest is "cosmetic" for

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -211,10 +211,8 @@ static void physics_subframe(motorst* mot, player_keys* keys, bike_metadata* met
 
         bool draw_view = metadata->draw_view;
         memset(metadata, 0, sizeof(bike_metadata));
-        metadata->bike_turning.camera_turn_time = -1000.0;
-        metadata->bike_turning.bike_turn_time = -1000.0;
-        metadata->camera_turning.camera_turn_time = -1000.0;
-        metadata->camera_turning.bike_turn_time = -1000.0;
+        metadata->bike_turning.turn_time = -1000.0;
+        metadata->camera_turning.turn_time = -1000.0;
         metadata->volt_time = -100.0;
         metadata->draw_view = draw_view;
 
@@ -285,7 +283,7 @@ static void update_bike_turn_phase(turning_data* data, recorder* rec, double tim
     if (data->flipped != flipped) {
         // New flip this frame
         data->flipped = flipped;
-        data->bike_turn_time = time;
+        data->turn_time = time;
         if (rec) {
             start_wav(WavEvent::Turn, 0.99);
             rec->store_event(time, WavEvent::Turn, 0.99, -1);
@@ -295,10 +293,10 @@ static void update_bike_turn_phase(turning_data* data, recorder* rec, double tim
     double turn_time = EolSettings->turn_time();
     if (turn_time == 0.0) {
         // Instant turn
-        data->bike_turn_phase = 1.0;
+        data->turn_phase = 1.0;
     } else {
-        data->bike_turn_phase = (time - data->bike_turn_time) / turn_time;
-        data->bike_turn_phase = std::clamp(data->bike_turn_phase, 0.0, 1.0);
+        data->turn_phase = (time - data->turn_time) / turn_time;
+        data->turn_phase = std::clamp(data->turn_phase, 0.0, 1.0);
     }
 }
 
@@ -307,21 +305,21 @@ static void update_camera_turn_phase(turning_data* data, double time, int flippe
     if (data->flipped != flipped) {
         // New flip this frame
         data->flipped = flipped;
-        double time_since_prev_turn = time - data->camera_turn_time;
+        double time_since_prev_turn = time - data->turn_time;
         if (camera_flip_time > 0.0 && time_since_prev_turn < camera_flip_time) {
             // If camera is mid-turn, calculate camera start time so it seamlessly continues from
             // the mid-turn position
-            data->camera_turn_time = time + time_since_prev_turn - camera_flip_time;
+            data->turn_time = time + time_since_prev_turn - camera_flip_time;
         } else {
             // Camera is not mid-turn, so just set the camera turn time normally
-            data->camera_turn_time = time;
+            data->turn_time = time;
         }
     }
 
-    double elapsed_time = std::max(0.0, time - data->camera_turn_time);
-    data->camera_turn_phase = std::min(1.0, elapsed_time / camera_flip_time);
+    double elapsed_time = std::max(0.0, time - data->turn_time);
+    data->turn_phase = std::min(1.0, elapsed_time / camera_flip_time);
     if (flipped) {
-        data->camera_turn_phase = 1.0 - data->camera_turn_phase;
+        data->turn_phase = 1.0 - data->turn_phase;
     }
 }
 
@@ -483,10 +481,8 @@ int game_loop(const char* filename, CameraMode camera_mode) {
     memset(&metadata1, 0, sizeof(metadata1));
     bike_metadata metadata2;
     memset(&metadata2, 0, sizeof(metadata2));
-    metadata1.bike_turning.camera_turn_time = metadata2.bike_turning.camera_turn_time = -1000.0;
-    metadata1.bike_turning.bike_turn_time = metadata2.bike_turning.bike_turn_time = -1000.0;
-    metadata1.camera_turning.camera_turn_time = metadata2.camera_turning.camera_turn_time = -1000.0;
-    metadata1.camera_turning.bike_turn_time = metadata2.camera_turning.bike_turn_time = -1000.0;
+    metadata1.bike_turning.turn_time = metadata2.bike_turning.turn_time = -1000.0;
+    metadata1.camera_turning.turn_time = metadata2.camera_turning.turn_time = -1000.0;
     metadata1.volt_time = metadata2.volt_time = -100.0;
     metadata1.draw_view = metadata2.draw_view = true;
 
@@ -680,15 +676,11 @@ static void rewind_override_animations(bike_metadata* metadata, motorst* mot, re
     double turn_time = rec->find_last_turn_frame_time(time);
 
     metadata->bike_turning.flipped = mot->flipped_bike;
-    metadata->bike_turning.bike_turn_time = turn_time;
-    metadata->bike_turning.camera_turn_time = turn_time;
+    metadata->bike_turning.turn_time = turn_time;
     update_bike_turn_phase(&metadata->bike_turning, nullptr, time, mot->flipped_bike);
 
-    metadata->camera_turning.flipped = mot->flipped_camera;
-    metadata->camera_turning.bike_turn_time = time - 1000.0;
-    metadata->camera_turning.camera_turn_time = time - 1000.0;
-    metadata->camera_turning.bike_turn_phase = 1.0;
-    metadata->camera_turning.camera_turn_phase = mot->flipped_camera ? 0.0 : 1.0;
+    metadata->camera_turning.turn_time = time - 1000.0;
+    metadata->camera_turning.turn_phase = metadata->camera_turning.flipped ? 0.0 : 1.0;
 
     metadata->volt_time = rec->find_last_volt_time(time, &metadata->volt_is_right);
     metadata->arm_position = 1.0 - (time - metadata->volt_time) / VoltDelay;
@@ -765,10 +757,8 @@ int replay_loop(const char* filename, int restore_player_visibility) {
     memset(&metadata1, 0, sizeof(metadata1));
     bike_metadata metadata2;
     memset(&metadata2, 0, sizeof(metadata2));
-    metadata1.bike_turning.camera_turn_time = metadata2.bike_turning.camera_turn_time = -1000.0;
-    metadata1.bike_turning.bike_turn_time = metadata2.bike_turning.bike_turn_time = -1000.0;
-    metadata1.camera_turning.camera_turn_time = metadata2.camera_turning.camera_turn_time = -1000.0;
-    metadata1.camera_turning.bike_turn_time = metadata2.camera_turning.bike_turn_time = -1000.0;
+    metadata1.bike_turning.turn_time = metadata2.bike_turning.turn_time = -1000.0;
+    metadata1.camera_turning.turn_time = metadata2.camera_turning.turn_time = -1000.0;
     metadata1.volt_time = metadata2.volt_time = -100.0;
 
     metadata1.draw_view = true;
@@ -960,10 +950,8 @@ void render_replay(const char* level_filename) {
     memset(&metadata1, 0, sizeof(metadata1));
     bike_metadata metadata2;
     memset(&metadata2, 0, sizeof(metadata2));
-    metadata1.bike_turning.camera_turn_time = metadata2.bike_turning.camera_turn_time = -1000.0;
-    metadata1.bike_turning.bike_turn_time = metadata2.bike_turning.bike_turn_time = -1000.0;
-    metadata1.camera_turning.camera_turn_time = metadata2.camera_turning.camera_turn_time = -1000.0;
-    metadata1.camera_turning.bike_turn_time = metadata2.camera_turning.bike_turn_time = -1000.0;
+    metadata1.bike_turning.turn_time = metadata2.bike_turning.turn_time = -1000.0;
+    metadata1.camera_turning.turn_time = metadata2.camera_turning.turn_time = -1000.0;
     metadata1.volt_time = metadata2.volt_time = -100.0;
     metadata1.draw_view = true;
     metadata2.draw_view = true;

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -329,11 +329,11 @@ static void update_graphical_metadata(motorst& mot, bike_metadata& metadata, rec
     update_bike_turn_phase(&metadata.bike_turning, rec, time, mot.flipped_bike);
 
     // Update camera position
-    mot.flipped_camera = mot.flipped_bike;
+    int flipped_camera = mot.flipped_bike;
     if (mot.gravity_direction == MotorGravity::Up) {
-        mot.flipped_camera = !mot.flipped_camera;
+        flipped_camera = !flipped_camera;
     }
-    update_camera_turn_phase(&metadata.camera_turning, time, mot.flipped_camera);
+    update_camera_turn_phase(&metadata.camera_turning, time, flipped_camera);
 
     // Update arm position
     metadata.arm_position = std::max(0.0, 1.0 - (time - metadata.volt_time) / VoltDelay);

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -280,29 +280,17 @@ static void update_view_settings(player_keys* keys, bike_metadata* metadata, boo
     }
 }
 
-static void update_turn_time(turning_data* data, recorder* rec, double time, int flipped) {
+// The `rec` argument is only used for game play, not when playing a replay.
+static void update_bike_turn_phase(turning_data* data, recorder* rec, double time, int flipped) {
     if (data->flipped != flipped) {
         // New flip this frame
         data->bike_turn_time = time;
-        double elapsed_time = time - data->camera_turn_time;
-        double camera_flip_time = EolSettings->turn_time() + 0.15;
-        if (camera_flip_time > 0.0 && elapsed_time < camera_flip_time) {
-            // If camera is mid-turn, calculate camera start time so it seamlessly continues from
-            // the mid-turn position
-            data->camera_turn_time = time + elapsed_time - camera_flip_time;
-        } else {
-            // Camera is not mid-turn, so just set the camera turn time normally
-            data->camera_turn_time = time;
-        }
-        data->flipped = flipped;
         if (rec) {
             start_wav(WavEvent::Turn, 0.99);
             rec->store_event(time, WavEvent::Turn, 0.99, -1);
         }
     }
-}
 
-static void update_bike_turn_phase(turning_data* data, double time, int flipped) {
     double turn_time = EolSettings->turn_time();
     if (turn_time == 0.0) {
         // Instant turn
@@ -315,6 +303,19 @@ static void update_bike_turn_phase(turning_data* data, double time, int flipped)
 
 static void update_camera_turn_phase(turning_data* data, double time, int flipped) {
     double camera_flip_time = EolSettings->turn_time() + 0.15;
+    if (data->flipped != flipped) {
+        // New flip this frame
+        double time_since_prev_turn = time - data->camera_turn_time;
+        if (camera_flip_time > 0.0 && time_since_prev_turn < camera_flip_time) {
+            // If camera is mid-turn, calculate camera start time so it seamlessly continues from
+            // the mid-turn position
+            data->camera_turn_time = time + time_since_prev_turn - camera_flip_time;
+        } else {
+            // Camera is not mid-turn, so just set the camera turn time normally
+            data->camera_turn_time = time;
+        }
+    }
+
     double elapsed_time = std::max(0.0, time - data->camera_turn_time);
     data->camera_turn_phase = std::min(1.0, elapsed_time / camera_flip_time);
     if (flipped) {
@@ -325,9 +326,9 @@ static void update_camera_turn_phase(turning_data* data, double time, int flippe
 static void update_graphical_metadata(motorst& mot, bike_metadata& metadata, recorder* rec,
                                       double time) {
     // Update bike turn data
-    update_turn_time(&metadata.bike_turning, rec, time, mot.flipped_bike);
-    update_bike_turn_phase(&metadata.bike_turning, time, mot.flipped_bike);
+    update_bike_turn_phase(&metadata.bike_turning, rec, time, mot.flipped_bike);
     update_camera_turn_phase(&metadata.bike_turning, time, mot.flipped_bike);
+    metadata.bike_turning.flipped = mot.flipped_bike;
 
     // Update camera position
     mot.flipped_camera = mot.flipped_bike;
@@ -335,9 +336,9 @@ static void update_graphical_metadata(motorst& mot, bike_metadata& metadata, rec
         mot.flipped_camera = !mot.flipped_camera;
     }
 
-    update_turn_time(&metadata.camera_turning, nullptr, time, mot.flipped_camera);
-    update_bike_turn_phase(&metadata.camera_turning, time, mot.flipped_camera);
+    update_bike_turn_phase(&metadata.camera_turning, nullptr, time, mot.flipped_camera);
     update_camera_turn_phase(&metadata.camera_turning, time, mot.flipped_camera);
+    metadata.camera_turning.flipped = mot.flipped_camera;
 
     // Update arm position
     metadata.arm_position = std::max(0.0, 1.0 - (time - metadata.volt_time) / VoltDelay);
@@ -684,8 +685,7 @@ static void rewind_override_animations(bike_metadata* metadata, motorst* mot, re
     metadata->bike_turning.flipped = mot->flipped_bike;
     metadata->bike_turning.bike_turn_time = turn_time;
     metadata->bike_turning.camera_turn_time = turn_time;
-    update_turn_time(&metadata->bike_turning, nullptr, time, mot->flipped_bike);
-    update_bike_turn_phase(&metadata->bike_turning, time, mot->flipped_bike);
+    update_bike_turn_phase(&metadata->bike_turning, nullptr, time, mot->flipped_bike);
     update_camera_turn_phase(&metadata->bike_turning, time, mot->flipped_bike);
 
     metadata->camera_turning.flipped = mot->flipped_camera;

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -144,18 +144,6 @@ static BikeState handle_object_interaction(int object_id, int* apple_count, moto
     return BikeState::Normal;
 }
 
-// Return camera phase (position) from 1.0 (facing left) to 0.0 (facing right)
-static double calculate_camera_phase(double elapsed_time, int flipped) {
-    elapsed_time = std::max(elapsed_time, 0.0);
-
-    double camera_flip_time = EolSettings->turn_time() + 0.15;
-    double phase = std::min(1.0, elapsed_time / camera_flip_time);
-    if (flipped) {
-        phase = 1.0 - phase;
-    }
-    return phase;
-}
-
 // Subframe physics calculation. Contains all the physics calculations except for bike turning
 static void physics_subframe(motorst* mot, player_keys* keys, bike_metadata* metadata,
                              recorder* rec, int* finish_time, bool* dead, double time, double dt) {
@@ -326,7 +314,12 @@ static void update_bike_turn_phase(turning_data* data, double time, int flipped)
 }
 
 static void update_camera_turn_phase(turning_data* data, double time, int flipped) {
-    data->camera_turn_phase = calculate_camera_phase(time - data->camera_turn_time, flipped);
+    double camera_flip_time = EolSettings->turn_time() + 0.15;
+    double elapsed_time = std::max(0.0, time - data->camera_turn_time);
+    data->camera_turn_phase = std::min(1.0, elapsed_time / camera_flip_time);
+    if (flipped) {
+        data->camera_turn_phase = 1.0 - data->camera_turn_phase;
+    }
 }
 
 static void update_turning_data(turning_data* data, recorder* rec, double time, int flipped) {

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -322,10 +322,25 @@ static void update_camera_turn_phase(turning_data* data, double time, int flippe
     }
 }
 
-static void update_turning_data(turning_data* data, recorder* rec, double time, int flipped) {
-    update_turn_time(data, rec, time, flipped);
-    update_bike_turn_phase(data, time, flipped);
-    update_camera_turn_phase(data, time, flipped);
+static void update_graphical_metadata(motorst& mot, bike_metadata& metadata, recorder* rec,
+                                      double time) {
+    // Update bike turn data
+    update_turn_time(&metadata.bike_turning, rec, time, mot.flipped_bike);
+    update_bike_turn_phase(&metadata.bike_turning, time, mot.flipped_bike);
+    update_camera_turn_phase(&metadata.bike_turning, time, mot.flipped_bike);
+
+    // Update camera position
+    mot.flipped_camera = mot.flipped_bike;
+    if (mot.gravity_direction == MotorGravity::Up) {
+        mot.flipped_camera = !mot.flipped_camera;
+    }
+
+    update_turn_time(&metadata.camera_turning, nullptr, time, mot.flipped_camera);
+    update_bike_turn_phase(&metadata.camera_turning, time, mot.flipped_camera);
+    update_camera_turn_phase(&metadata.camera_turning, time, mot.flipped_camera);
+
+    // Update arm position
+    metadata.arm_position = std::max(0.0, 1.0 - (time - metadata.volt_time) / VoltDelay);
 }
 
 // The only physics-relevant part of this function is turning the bike. The rest is "cosmetic" for
@@ -352,22 +367,8 @@ static void physics_frame_end(motorst* mot, player_keys* keys, bike_metadata* me
         }
         metadata->turn_key_previous = is_turn_down;
     }
-    update_turning_data(&metadata->bike_turning, rec, time, mot->flipped_bike);
 
-    // Update camera position
-    mot->flipped_camera = mot->flipped_bike;
-    if (mot->gravity_direction == MotorGravity::Up) {
-        mot->flipped_camera = !mot->flipped_camera;
-    }
-    update_turning_data(&metadata->camera_turning, nullptr, time, mot->flipped_camera);
-
-    // Update arm position
-    metadata->arm_position = std::max(0.0, 1.0 - (time - metadata->volt_time) / VoltDelay);
-#ifdef DEBUG
-    if (metadata->arm_position > 1.00001) {
-        internal_error("metadata->arm_position > 1.00001!");
-    }
-#endif
+    update_graphical_metadata(*mot, *metadata, rec, time);
 }
 
 static void handle_eol_inputs() {
@@ -683,7 +684,9 @@ static void rewind_override_animations(bike_metadata* metadata, motorst* mot, re
     metadata->bike_turning.flipped = mot->flipped_bike;
     metadata->bike_turning.bike_turn_time = turn_time;
     metadata->bike_turning.camera_turn_time = turn_time;
-    update_turning_data(&metadata->bike_turning, nullptr, time, mot->flipped_bike);
+    update_turn_time(&metadata->bike_turning, nullptr, time, mot->flipped_bike);
+    update_bike_turn_phase(&metadata->bike_turning, time, mot->flipped_bike);
+    update_camera_turn_phase(&metadata->bike_turning, time, mot->flipped_bike);
 
     metadata->camera_turning.flipped = mot->flipped_camera;
     metadata->camera_turning.bike_turn_time = time - 1000.0;
@@ -730,18 +733,7 @@ static bool replay_frame(motorst* mot, player_keys* keys, bike_metadata* metadat
         }
     }
 
-    // Update turn graphics
-    update_turning_data(&metadata->bike_turning, nullptr, time, mot->flipped_bike);
-
-    // Update camera position
-    mot->flipped_camera = mot->flipped_bike;
-    if (mot->gravity_direction == MotorGravity::Up) {
-        mot->flipped_camera = !mot->flipped_camera;
-    }
-    update_turning_data(&metadata->camera_turning, nullptr, time, mot->flipped_camera);
-
-    // Update arm position
-    metadata->arm_position = std::max(0.0, 1.0 - (time - metadata->volt_time) / VoltDelay);
+    update_graphical_metadata(*mot, *metadata, nullptr, time);
 
     return alive;
 }

--- a/LEJATSZO.H
+++ b/LEJATSZO.H
@@ -33,10 +33,8 @@ void render_replay(const char* level_filename);
 
 struct turning_data {
     int flipped;
-    double bike_turn_time;
-    double camera_turn_time;
-    double camera_turn_phase;
-    double bike_turn_phase;
+    double turn_time;
+    double turn_phase;
 };
 
 struct bike_metadata {

--- a/physics_init.cpp
+++ b/physics_init.cpp
@@ -43,7 +43,6 @@ double MetersToMinimapPixels;
 
 void init_motor(motorst* motor) {
     motor->flipped_bike = 0;
-    motor->flipped_camera = 0;
     motor->gravity_direction = MotorGravity::Down;
     motor->prev_brake = false;
 

--- a/physics_init.h
+++ b/physics_init.h
@@ -52,7 +52,6 @@ struct motorst {
     rigidbody right_wheel;
     vect2 head_r;
     int flipped_bike;
-    int flipped_camera;
     MotorGravity gravity_direction;
 
     vect2 body_r;

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -392,7 +392,7 @@ static void render_bike(bool player1, pic8* pic, double time, vect2 bottomleft_c
                         const motorst* mot, const bike_metadata* metadata, const bike_pics* bike,
                         const pic8* shirt) {
     double arm_position = metadata->arm_position;
-    double turn_phase = metadata->bike_turning.bike_turn_phase;
+    double turn_phase = metadata->bike_turning.turn_phase;
 
     // Check to see if bike is turning, and calculate the progress from -1.0 to 1.0 using cos
     bool is_turning = false;
@@ -624,7 +624,7 @@ static void render_view(bool player1, pic8* pic, double time, motorst* mot, bike
     }
 
     vect2 bottomleft_corner(bike_center.x -
-                                (CameraX + metadata->camera_turning.camera_turn_phase * CameraDx),
+                                (CameraX + metadata->camera_turning.turn_phase * CameraDx),
                             bike_center.y - CameraY);
     vect2 center(bottomleft_corner.x + (SCREEN_WIDTH / 2.0) * PixelsToMeters,
                  bottomleft_corner.y + (SCREEN_HEIGHT / 2.0) * PixelsToMeters);
@@ -766,10 +766,9 @@ static void render_view(bool player1, pic8* pic, double time, motorst* mot, bike
     // Draw the minimap
     if (show_minimap) {
         if (Single) {
-            render_minimap(player1, pic, metadata->camera_turning.camera_turn_phase, bike_center,
-                           nullptr);
+            render_minimap(player1, pic, metadata->camera_turning.turn_phase, bike_center, nullptr);
         } else {
-            render_minimap(player1, pic, metadata->camera_turning.camera_turn_phase, bike_center,
+            render_minimap(player1, pic, metadata->camera_turning.turn_phase, bike_center,
                            other_mot);
         }
     }


### PR DESCRIPTION
This is a lot of commits to only do a few small things:

- bike_metadata contains two copies of camera position and two copies of bike turn state (probably due to Across->Elma transition). we simplify to have one copy of camera position and one copy of bike turn state
- A bit of general cleanup associated with

Lots of commits so the logic makes sense. Theoretically you could squash all of this