### PR TITLE
fix(editor_window): possible ASAN when selecting mask in Create Picture

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -88,6 +88,7 @@
 * You can open level and replay files with multiple dots e.g. pack.01.lev
 * Minimap icons no longer disappear 1 pixel too early at the edge of the minimap
 * Changing an apples animation number is now correctly saved by Save and Play
+* Incorrect texture distance/clipping data no longer erroneously appears when selecting a mask in Create Picture
 
 ## Removed Legacy Features
 * It is no longer possible to upgrade from across.res to elma.res

--- a/src/editor/window.cpp
+++ b/src/editor/window.cpp
@@ -797,9 +797,9 @@ static void editor_window_select_sprite_name(char* picture_name, char* texture_n
                 }
                 Pabc2->write(BufferMain, lx1 + 3, ly1 + 15 + i * dy, name_at(i + view_index));
 
-                if (picture_name[0] || texture_name[0]) {
+                if (sprite_type == SpriteType::Picture || sprite_type == SpriteType::Texture) {
                     int default_distance = 0;
-                    if (picture_name[0]) {
+                    if (sprite_type == SpriteType::Picture) {
                         default_distance = Lgr->pictures[i + view_index].default_distance;
                     } else {
                         default_distance = Lgr->textures[i + view_index].default_distance;
@@ -809,7 +809,7 @@ static void editor_window_select_sprite_name(char* picture_name, char* texture_n
                     sprintf(details, "%d", default_distance);
                     Pabc2->write(BufferMain, lx1 + 67, ly1 + 15 + i * dy, details);
                     Clipping default_clipping = Clipping::Unclipped;
-                    if (picture_name[0]) {
+                    if (sprite_type == SpriteType::Picture) {
                         default_clipping = Lgr->pictures[i + view_index].default_clipping;
                     } else {
                         default_clipping = Lgr->textures[i + view_index].default_clipping;


### PR DESCRIPTION
Steps to reproduce:
- In editor, Create Picture then right-click
- Choose a random texture
- Open the mask dialog. The mask list will erroneously be populated with texture default distance/clipping data. If len(masks) > len(textures), an out-of-bounds reference occurs as well.