### PR TITLE
fix(eol): fix printing junk after chat lines

### DIFF
--- a/src/eol/eol.cpp
+++ b/src/eol/eol.cpp
@@ -144,7 +144,7 @@ void eol::process(const chat_message& msg) {
     std::string_view nick = lookup_nick(msg.kuski_id);
     tm tm = local_tm(msg.unix_timestamp);
     std::string line = std::format("{:02}:{:02}:{:02} <{}> {}", tm.tm_hour, tm.tm_min, tm.tm_sec,
-                                   nick, msg.message);
+                                   nick, (const char*)msg.message);
     Console->add_line(line, console::LineType::Chat);
 }
 
@@ -153,7 +153,7 @@ void eol::process(const private_message& msg) {
     std::string_view to_nick = lookup_nick(msg.to_kuski_id);
     tm tm = local_tm(msg.unix_timestamp);
     std::string line = std::format("{:02}:{:02}:{:02} <{}>-><{}> {}", tm.tm_hour, tm.tm_min,
-                                   tm.tm_sec, from_nick, to_nick, msg.message);
+                                   tm.tm_sec, from_nick, to_nick, (const char*)msg.message);
     Console->add_line(line, console::LineType::Pm);
 }
 
@@ -161,7 +161,7 @@ void eol::process(const team_message& msg) {
     std::string_view nick = lookup_nick(msg.from_kuski_id);
     tm tm = local_tm(msg.unix_timestamp);
     std::string line = std::format("{:02}:{:02}:{:02} [Team] <{}> {}", tm.tm_hour, tm.tm_min,
-                                   tm.tm_sec, nick, msg.message);
+                                   tm.tm_sec, nick, (const char*)msg.message);
     Console->add_line(line, console::LineType::Team);
 }
 


### PR DESCRIPTION
`chat::message` is a char array, and `std::format()` copies the entire thing to the `std::string`. This means a `std::string` could be constructed containing an embeded '\0' character. This behaviour seems to be implementation defined.

This worked because `abc8::write()` writes all characters up until the first '\0' character.

However commit e66c0ef7c4cd ("fix(console): strip unrenderable chars from added lines"), stripped the embedded '\0', which caused the junk data to appear.

Fix it by casting `message` to a `const char*`, which causes `std::format()` to only copy until the first '\0'.