### PR TITLE
chore(ci): install SDL2 backend deps for static build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,13 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgl1-mesa-dev
+          sudo apt-get install -y \
+            libgl1-mesa-dev \
+            libwayland-dev wayland-protocols libxkbcommon-dev libdecor-0-dev \
+            libx11-dev libxext-dev libxcursor-dev libxi-dev \
+            libxrandr-dev libxss-dev libxinerama-dev libxxf86vm-dev \
+            libegl-dev libgbm-dev \
+            libpulse-dev libasound2-dev libdbus-1-dev libudev-dev libibus-1.0-dev
 
       - name: Visual Studio
         if: runner.os == 'windows'


### PR DESCRIPTION
SDL2 is built as a static meson subproject. With only libgl1-mesa-dev present, its configure silently disabled every video and audio backend, producing binaries that failed at launch with "No available video device".

Install the X11, Wayland, ALSA and PulseAudio dev packages so SDL2 ships with real backends compiled in.