### PR TITLE
fix(sdl): drop `SDL_TEXTINPUT` events while LCtrl search is active

### DIFF
--- a/src/platform/sdl/sdl.cpp
+++ b/src/platform/sdl/sdl.cpp
@@ -433,8 +433,9 @@ void handle_events() {
             }
 #endif
 
-            // SDL doesn't generate text input events when Ctrl is held
-            // Resolve layout-specific keycodes to support LCtrl search
+            // On macos, SDL suppresses SDL_TEXTINPUT while Ctrl is held, so
+            // resolve the layout-specific keycode here to support LCtrl search.
+            // Wayland delivers SDL_TEXTINPUT anyway and is de-duplicated below.
             if (EolSettings->lctrl_search()) {
                 bool is_lctrl_pressed = event.key.keysym.mod & KMOD_LCTRL;
                 if (is_lctrl_pressed) {
@@ -447,6 +448,10 @@ void handle_events() {
             break;
         }
         case SDL_TEXTINPUT:
+            // Disallow SDL_TEXTINPUT if lctrl is held
+            if (EolSettings->lctrl_search() && (SDL_GetModState() & KMOD_LCTRL)) {
+                break;
+            }
             add_text_to_buffer(event.text.text);
             break;
         case SDL_MOUSEWHEEL:


### PR DESCRIPTION
On Wayland, SDL fires `SDL_TEXTINPUT` even when Ctrl is held, but only for keys whose Ctrl+key combination has no control-character mapping in xkb (0, 1, 9, comma, period, hyphen, etc.). The LCtrl-search workaround in `SDL_KEYDOWN` already inserts the character, so these keys ended up doubled in the search buffer ("1" -> "11", "11" -> "1111") while other keys worked correctly because their `SDL_TEXTINPUT` payload was a control byte and got filtered out as non-printable.

Skip `SDL_TEXTINPUT` entirely while LCtrl-search is active; the `SDL_KEYDOWN` branch is the single source of truth for that mode.