### PR TITLE
fix(input): keep numpad as numpad during gameplay

### DIFF
--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -14,6 +14,7 @@
 #include "object.h"
 #include "physics_init.h"
 #include "platform/implementation.h"
+#include "platform/sdl/keyboard.h"
 #include "segments.h"
 #include "timer.h"
 #include <algorithm>
@@ -400,7 +401,18 @@ static void setup_gameloop(const char* filename) {
 int WhoDiedFirst = 0;
 bool Player1Finished = false;
 
+namespace {
+struct NumpadNavGuard {
+    NumpadNavGuard() { keyboard::set_numpad_nav(false); }
+    ~NumpadNavGuard() { keyboard::set_numpad_nav(true); }
+};
+} // namespace
+
 int game_loop(const char* filename, CameraMode camera_mode) {
+    // Bindings during gameplay must be honored by raw scancode: numpad-6
+    // is right-volt, not "Right Arrow when NumLock is off".
+    NumpadNavGuard numpad_nav_guard;
+
     WhoDiedFirst = 0;
     Player1Finished = false;
 
@@ -725,6 +737,10 @@ static bool PreviousReplayDrawView1 = true;
 static bool PreviousReplayDrawView2 = true;
 
 int replay_loop(const char* filename, int restore_player_visibility) {
+    // Bindings during gameplay must be honored by raw scancode: numpad-6
+    // is right-volt, not "Right Arrow when NumLock is off".
+    NumpadNavGuard numpad_nav_guard;
+
     // Refuse to play zero-length replays (from map-viewer mode)
     if (Rec1->is_empty()) {
         return -2;

--- a/include/platform/sdl/keyboard.h
+++ b/include/platform/sdl/keyboard.h
@@ -12,6 +12,7 @@ void record_key_down(SDL_Scancode scancode);
 bool is_down(SDL_Scancode sdl_code);
 bool was_just_pressed(SDL_Scancode sdl_code);
 bool was_down(SDL_Scancode sdl_code);
+void set_numpad_nav(bool enabled);
 
 } // namespace keyboard
 

--- a/src/platform/sdl/keyboard.cpp
+++ b/src/platform/sdl/keyboard.cpp
@@ -19,6 +19,7 @@ static const Uint8* SdlLive = nullptr;
 static Uint8 Current[SDL_NUM_SCANCODES];
 static Uint8 Previous[SDL_NUM_SCANCODES];
 static bool WasDown[SDL_NUM_SCANCODES];
+static bool NumpadNavEnabled = true;
 
 void init() {
     SdlLive = SDL_GetKeyboardState(nullptr);
@@ -34,13 +35,17 @@ void begin_frame() {
 void end_frame() {
     memcpy(Current, SdlLive, sizeof(Current));
 
-    // Map numpad keys to navigation equivalents when in navigation mode.
-    // On macOS, KMOD_NUM is unreliable (SDL never initializes it from OS state),
-    // so we always map numpad keys to text input — macOS has no NumLock key anyway.
 #ifdef __APPLE__
+    // macos has no numlock key so we always force numpad navigation off
     bool numpad_nav = false;
 #else
-    bool numpad_nav = !(SDL_GetModState() & KMOD_NUM);
+    // Map numpad keys to navigation equivalents when in navigation mode.
+    // On Windows/Linux the behavior depends on the numlock state and global state.
+    // We want gameplay inputs to always fire regardless of numlock state and
+    // other menus fire the respective key. This is because when in the editor
+    // pressing numpad 4 should either write 4 or navigate left, without this
+    // we would fire both inputs
+    bool numpad_nav = NumpadNavEnabled && !(SDL_GetModState() & KMOD_NUM);
 #endif
     for (auto& [numpad, nav] : NUMPAD_NAV_MAP) {
         // KP_ENTER always maps to Return regardless of NumLock
@@ -56,6 +61,8 @@ void end_frame() {
 }
 
 void record_key_down(SDL_Scancode scancode) { WasDown[scancode] = true; }
+
+void set_numpad_nav(bool enabled) { NumpadNavEnabled = enabled; }
 
 bool is_down(SDL_Scancode sdl_code) { return Current[sdl_code] != 0; }
 


### PR DESCRIPTION
The NumLock-off numpad-to-arrow remap in `keyboard::end_frame()` runs globally, so any gameplay binding on numpad-6 also fires the Right Arrow binding (and likewise for 8/4/2/9/3/period). Multiplayer setups that overload the right cluster (e.g. disconnect on Right Arrow, right-volt on numpad-6) trigger both actions on a single keypress, and users have to toggle NumLock every time they switch between menus and play.

Add a `keyboard::set_numpad_nav` toggle and disable the remap for the duration of game_loop, so during play scancode in = scancode out. Other places keep respecting numlock to prevent firing both textinput and navigation keys.