### PR TITLE
fix(eol): add apple count and prefix for F6 table

### DIFF
--- a/include/eol/eol.h
+++ b/include/eol/eol.h
@@ -68,6 +68,8 @@ class eol {
     void sync_battle_results_table();
     void sync_battle_queue_table();
 
+    void set_battle_results_title(const char* label);
+
     const std::vector<kuski>& all_kuskis() const { return kuskis_; }
     std::string_view lookup_nick(unsigned int kuski_id) const;
 

--- a/src/eol/battle.cpp
+++ b/src/eol/battle.cpp
@@ -39,8 +39,17 @@ std::string eol::format_level(std::string_view level) {
 }
 
 void eol::set_battle_results_title(const char* label) {
-    battle_results_table.set_title(
-        std::format("Battle {} in {}", label, format_level(current_battle->level_filename)));
+    std::string new_title;
+    if (current_battle->type == BattleType::AppleCollect) {
+        uint32_t apple_count = current_battle->level_apple_count;
+        new_title = std::format("Apple battle {} in {} ({} apple{})", label,
+                                format_level(current_battle->level_filename), apple_count,
+                                apple_count == 1 ? "" : "s");
+    } else {
+        new_title =
+            std::format("Battle {} in {}", label, format_level(current_battle->level_filename));
+    }
+    battle_results_table.set_title(new_title);
 }
 
 void eol::process(const battle_started& bs) {

--- a/src/eol/battle.cpp
+++ b/src/eol/battle.cpp
@@ -38,13 +38,17 @@ std::string eol::format_level(std::string_view level) {
     return with_ext;
 }
 
+void eol::set_battle_results_title(const char* label) {
+    battle_results_table.set_title(
+        std::format("Battle {} in {}", label, format_level(current_battle->level_filename)));
+}
+
 void eol::process(const battle_started& bs) {
     current_battle = bs.bat;
     current_battle->level_exists = std::filesystem::exists(
         std::format("lev/{}.lev", (const char*)current_battle->level_filename));
     battle_leaderboard_.clear();
-    battle_results_table.set_title(
-        std::format("Battle standings in {}", format_level(current_battle->level_filename)));
+    set_battle_results_title("standings");
     sync_battle_results_table();
 
     if (current_battle->in_countdown) {
@@ -66,8 +70,7 @@ void eol::process(const battle_countdown_ended&) {
 }
 
 void eol::process(const battle_ended& be) {
-    battle_results_table.set_title(
-        std::format("Battle results in {}", format_level(current_battle->level_filename)));
+    set_battle_results_title("results");
     current_battle.reset();
     StatusMessages->add(be.aborted ? "battle aborted" : "battle over");
 }


### PR DESCRIPTION
didn't test online yet, just with this:

```
diff --git a/src/renderer/render.cpp b/src/renderer/render.cpp
index 6c809dec..093e7540 100644
--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -100,6 +100,14 @@ void init_renderer() {
     Console->set_font(SmallFont);
 
     StatusMessages = new status_messages();
+
+    battle b{};
+    strncpy((char*)b.level_filename, "abc", 3);
+    b.type = BattleType::AppleCollect;
+    b.duration = 1;
+    b.level_apple_count = 100000000;
+    EolClient->process(battle_started{b});
+    EolClient->process(battle_ended{});
 }
 
 // Determine the position of the view of player1 +- player2 on the screen

```