### PR TITLE
CLang-tidy cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install dependencies
         run: python -m pip install meson==1.10.0 ninja
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install dependencies
         run: python -m pip install meson==1.10.0 ninja
@@ -75,15 +75,15 @@ jobs:
 
           echo "No clang-tidy issues found."
           exit 0
-          fi
+
       - name: Show summary
         if: always()
         run: |
           echo "=== Clang-tidy Summary ==="
-          grep -E "warning:|error:" clang-tidy-output.txt 2>/dev/null
+          grep -E "warning:|error:" clang-tidy-output.txt 2>/dev/null || true
           echo ""
-          echo "Total warnings: $(grep -c "warning:" clang-tidy-output.txt || echo 0)"
-          echo "Total errors: $(grep -c "error:" clang-tidy-output.txt || echo 0)"
+          echo "Total warnings: $(grep -c "warning:" clang-tidy-output.txt || true)"
+          echo "Total errors: $(grep -c "error:" clang-tidy-output.txt || true)"
           echo ""
           echo "Full output available in artifacts"
 
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install dependencies
         run: python -m pip install meson==1.10.0 ninja

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -599,9 +599,8 @@ int game_loop(const char* filename, CameraMode camera_mode) {
                 Rec2->encode_frame_count();
                 if (finish_time) {
                     return finish_time;
-                } else {
-                    return -1;
                 }
+                return -1;
             }
             time += dt;
         }

--- a/LEJATSZO.CPP
+++ b/LEJATSZO.CPP
@@ -591,7 +591,7 @@ int game_loop(const char* filename, CameraMode camera_mode) {
 
                 if (Single) {
                     EolClient->exit_level(filename, time * TimeToCentiseconds, Motor1->apple_count,
-                                          TotalApples, finish_time ? false : true);
+                                          TotalApples, !finish_time);
                 }
 
                 Level->unflip_objects();

--- a/sound_engine.cpp
+++ b/sound_engine.cpp
@@ -217,9 +217,9 @@ static void mix_motor_sounds(bool is_motor1, short* buffer, int buffer_length) {
         switch (mot->motor_state) {
         case MotorState::Ignition:
             // Bike turn on sound at start of level
-            if (mot->playback_index_ignition + buffer_length > SoundMotorIgnition->size) {
+            if (mot->playback_index_ignition + buffer_length > SoundMotorIgnition->size()) {
                 // We're finished with the ignition sound. Transition to idle sound
-                source_length = SoundMotorIgnition->size - mot->playback_index_ignition;
+                source_length = SoundMotorIgnition->size() - mot->playback_index_ignition;
                 mix_into_buffer(&buffer[copied_counter],
                                 &SoundMotorIgnition->samples[mot->playback_index_ignition],
                                 source_length);
@@ -245,9 +245,9 @@ static void mix_motor_sounds(bool is_motor1, short* buffer, int buffer_length) {
             } else {
                 // Otherwise, infinitely loop the idle sound
                 source_length = buffer_length - copied_counter;
-                if (source_length > SoundMotorIdle->size - mot->playback_index_idle) {
+                if (source_length > SoundMotorIdle->size() - mot->playback_index_idle) {
                     // Copy until the end of the sound effect, then loop
-                    source_length = SoundMotorIdle->size - mot->playback_index_idle;
+                    source_length = SoundMotorIdle->size() - mot->playback_index_idle;
                     mix_into_buffer(&buffer[copied_counter],
                                     &SoundMotorIdle->samples[mot->playback_index_idle],
                                     source_length);
@@ -275,7 +275,7 @@ static void mix_motor_sounds(bool is_motor1, short* buffer, int buffer_length) {
             // Fade the first WAV_FADE_LENGTH samples
             fade_counter = 0;
             for (int i = mot->playback_index_gas_start; i < source_index_end; i++) {
-                if (mot->playback_index_idle >= SoundMotorIdle->size) {
+                if (mot->playback_index_idle >= SoundMotorIdle->size()) {
                     mot->playback_index_idle = 0;
                 }
                 double fade_percentage = i / (double)(WAV_FADE_LENGTH);
@@ -295,9 +295,9 @@ static void mix_motor_sounds(bool is_motor1, short* buffer, int buffer_length) {
         case MotorState::GasStart:
             // start-of-gas sound effect (sound frequency does not yet depend on speed)
             source_length = buffer_length - copied_counter;
-            if (source_length > SoundMotorGasStart->size - mot->playback_index_gas_start) {
+            if (source_length > SoundMotorGasStart->size() - mot->playback_index_gas_start) {
                 // We're finished with the start-of-gas sound. Transition to full gas sound
-                source_length = SoundMotorGasStart->size - mot->playback_index_gas_start;
+                source_length = SoundMotorGasStart->size() - mot->playback_index_gas_start;
                 mix_into_buffer(&buffer[copied_counter],
                                 &SoundMotorGasStart->samples[mot->playback_index_gas_start],
                                 source_length);
@@ -380,7 +380,7 @@ static void mix_friction(short* buffer, int buffer_length) {
     double volume = FrictionVolumePrev;
     double volume_next = FrictionVolumeNext;
     double delta_volume = (volume_next - volume) / buffer_length;
-    int sample_length = SoundFriction->size;
+    int sample_length = SoundFriction->size();
     for (int i = 0; i < buffer_length; i++) {
         short sample = SoundFriction->samples[SoundFrictionIndex];
         SoundFrictionIndex++;
@@ -417,8 +417,8 @@ void sound_mixer(short* buffer, int buffer_length) {
     for (int i = 0; i < MAX_WAV_EVENTS; i++) {
         if (WavEventActive[i]) {
             int length = buffer_length;
-            if (length > WavEventSound[i]->size - WavEventPlaybackIndex[i]) {
-                length = WavEventSound[i]->size - WavEventPlaybackIndex[i];
+            if (length > WavEventSound[i]->size() - WavEventPlaybackIndex[i]) {
+                length = WavEventSound[i]->size() - WavEventPlaybackIndex[i];
                 WavEventActive[i] = 0;
                 ActiveWavEvents--;
                 if (ActiveWavEvents < 0) {

--- a/src/editor/window.cpp
+++ b/src/editor/window.cpp
@@ -495,7 +495,7 @@ bool editor_window_save_as() {
             }
         }
         if (was_key_down(DIK_DELETE)) {
-            if (!((filename_input[0] == 0) || (i >= (int)strlen(filename_input)))) {
+            if (filename_input[0] != 0 && i < (int)strlen(filename_input)) {
                 int filename_input_length = strlen(filename_input);
                 for (int j = i; j < filename_input_length; j++) {
                     filename_input[j] = filename_input[j + 1];

--- a/src/editor/window.cpp
+++ b/src/editor/window.cpp
@@ -884,12 +884,14 @@ void editor_window_choose_sprite() {
         update_and_draw_cursor();
         if (was_key_just_pressed(DIK_ESCAPE) || clicked_box(box_cancel)) {
             return;
-        } else if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
+        }
+        if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
             strcpy(Lgr->editor_picture_name, picture_name);
             strcpy(Lgr->editor_texture_name, texture_name);
             strcpy(Lgr->editor_mask_name, mask_name);
             return;
-        } else if (clicked_box(box_picture)) {
+        }
+        if (clicked_box(box_picture)) {
             editor_window_select_sprite_name(picture_name, null_name, null_name,
                                              SpriteType::Picture);
             erase_cursor();
@@ -1159,14 +1161,16 @@ void editor_window_sprite_properties(sprite* spr) {
         update_and_draw_cursor();
         if (was_key_just_pressed(DIK_ESCAPE) || clicked_box(box_cancel)) {
             return;
-        } else if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
+        }
+        if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
             if (spr->distance != distance || spr->clipping != clipping) {
                 LevelChanged = true;
             }
             spr->distance = distance;
             spr->clipping = clipping;
             return;
-        } else if (clicked_box(box_distance)) {
+        }
+        if (clicked_box(box_distance)) {
             distance = prompt_distance(BufferMain, box_distance, distance);
             rerender = true;
         } else if (clicked_box(box_clipping)) {
@@ -1278,13 +1282,15 @@ void editor_window_polygon_properties(polygon* poly) {
         update_and_draw_cursor();
         if (was_key_just_pressed(DIK_ESCAPE) || clicked_box(box_cancel)) {
             return;
-        } else if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
+        }
+        if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
             if (poly->is_grass != is_grass) {
                 LevelChanged = true;
             }
             poly->is_grass = is_grass;
             return;
-        } else if (clicked_box(box_grass)) {
+        }
+        if (clicked_box(box_grass)) {
             is_grass = !is_grass;
             rerender = true;
         }
@@ -1400,7 +1406,8 @@ void editor_window_food_properties(const char* title, object::Property* property
         update_and_draw_cursor();
         if (was_key_just_pressed(DIK_ESCAPE) || clicked_box(box_cancel)) {
             return;
-        } else if (clicked_box(box_animation)) {
+        }
+        if (clicked_box(box_animation)) {
             erase_cursor();
             render_box(BufferMain, box_animation, EditorPaletteId::WINDOW_INPUT,
                        EditorPaletteId::WINDOW_BORDER);
@@ -1586,7 +1593,8 @@ void editor_window_level_properties() {
         update_and_draw_cursor();
         if (was_key_just_pressed(DIK_ESCAPE) || clicked_box(box_cancel)) {
             return;
-        } else if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
+        }
+        if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
             if (strcmpi(Level->foreground_name, foreground_name) != 0 ||
                 strcmpi(Level->background_name, background_name) != 0 ||
                 strcmp(Level->level_name, level_name) != 0) {
@@ -1605,7 +1613,8 @@ void editor_window_level_properties() {
                 }
             }
             return;
-        } else if (clicked_box(box_foreground)) {
+        }
+        if (clicked_box(box_foreground)) {
             char null_name[10] = "";
             char mask_name[10] = "";
             if (Lgr->get_mask_index("maskbig") >= 0) {
@@ -1723,7 +1732,8 @@ void editor_window_view_options() {
         if (was_key_just_pressed(DIK_ESCAPE) || was_key_just_pressed(DIK_RETURN) ||
             clicked_box(box_ok)) {
             return;
-        } else if (clicked_box(box_polygons)) {
+        }
+        if (clicked_box(box_polygons)) {
             ShowPolygons = !ShowPolygons;
             rerender = true;
         } else if (clicked_box(box_grass)) {

--- a/src/eol/console.cpp
+++ b/src/eol/console.cpp
@@ -116,7 +116,7 @@ void console::register_console_commands() {
     register_command("download", [](std::string_view text) { EolClient->download_level(text); });
     register_alias("dl", "download");
     register_command("download_battle",
-                     [](std::string_view text) { EolClient->download_battle_level(); });
+                     [](std::string_view /*text*/) { EolClient->download_battle_level(); });
     register_alias("dlb", "download");
 }
 

--- a/wav.cpp
+++ b/wav.cpp
@@ -5,16 +5,6 @@
 #include <algorithm>
 #include <cstring>
 
-void wav::allocate() {
-    if (size > 1000000) {
-        internal_error("wav::alloc size > 1000000!");
-    }
-    samples = new signed short[size];
-    if (!samples) {
-        external_error("wav::alloc out of memory!");
-    }
-}
-
 static void assert_filename_is_wav(const char* filename) {
     for (int i = strlen(filename) - 1; i > 0; i--) {
         if (filename[i] == '.') {
@@ -53,7 +43,6 @@ struct wav_header {
 static_assert(sizeof(wav_header) == 44);
 
 wav::wav(const char* filename, double max_volume, int start, int end) {
-    samples = nullptr;
     assert_filename_is_wav(filename);
     FILE* h = qopen(filename, "rb");
     if (!h) {
@@ -92,11 +81,14 @@ wav::wav(const char* filename, double max_volume, int start, int end) {
     if (end > source_size) {
         internal_error("wav::wav end is out of range!");
     }
-    size = end - start;
 
-    allocate();
+    int size = end - start;
+    if (size > 1000000) {
+        internal_error("wav::alloc size > 1000000!");
+    }
+    samples.resize(size);
     qseek(h, start * 2, SEEK_CUR);
-    if (fread(samples, 1, size * 2, h) != size * 2) {
+    if (fread(samples.data(), 1, size * sizeof(short), h) != size * sizeof(short)) {
         internal_error(std::string("Failed to read wav file: ") + filename);
     }
 
@@ -119,51 +111,48 @@ wav::wav(const char* filename, double max_volume, int start, int end) {
 }
 
 void wav::loop(int fade_length) {
-    if (fade_length >= size) {
+    if (fade_length >= size()) {
         internal_error("fade_length >= size!");
     }
     for (int i = 0; i < fade_length; i++) {
         double fade = ((double)i) / fade_length;
-        samples[i] = (short)(fade * samples[i] + (1 - fade) * samples[size - fade_length + i]);
+        samples[i] = (short)(fade * samples[i] + (1 - fade) * samples[size() - fade_length + i]);
     }
-    size -= fade_length;
+    samples.resize(size() - fade_length);
 }
 
 void wav::fade(wav* next, int fade_length) {
-    if (fade_length >= size) {
+    if (fade_length >= size()) {
         internal_error("fade_length >= size!");
     }
-    if (fade_length >= next->size) {
+    if (fade_length >= next->size()) {
         internal_error("fade_length >= next->size!");
     }
     for (int i = 0; i < fade_length; i++) {
         double fade = ((double)i) / fade_length;
-        samples[size - fade_length + i] =
+        samples[size() - fade_length + i] =
             (short)((1 - fade) * samples[i] + fade * next->samples[i]);
     }
 }
 
 void wav::volume(double scale) {
-    for (int i = 0; i < size; i++) {
+    for (int i = 0; i < size(); i++) {
         samples[i] = (short)(samples[i] * scale);
     }
 }
 
 wav2::wav2(wav* source) {
-    deltas = nullptr;
-    samples = source->samples;
-    if (source->size > 64000) {
+    if (source->size() > 64000) {
         internal_error("wav2 size > 64000!");
     }
-    deltas = new short[source->size];
-    if (!deltas) {
-        external_error("memory");
-    }
-    for (int i = 0; i < source->size - 1; i++) {
+    samples.resize(source->size());
+    deltas.resize(source->size());
+
+    memcpy(samples.data(), source->samples.data(), size() * sizeof(short));
+    for (int i = 0; i < size() - 1; i++) {
         deltas[i] = samples[i + 1] - samples[i];
     }
-    deltas[source->size - 1] = samples[0] - samples[source->size - 1];
-    size = source->size;
+    deltas[size() - 1] = samples[0] - samples[size() - 1];
     playback_index = 0.0;
 }
 
@@ -178,8 +167,8 @@ void wav2::reset(double index) {
 
 short wav2::get_next_sample(double dt) {
     playback_index += dt;
-    if (playback_index >= size) {
-        playback_index -= size;
+    if (playback_index >= size()) {
+        playback_index -= size();
     }
     int whole = (int)(playback_index);
     double fraction = playback_index - whole;

--- a/wav.h
+++ b/wav.h
@@ -1,17 +1,19 @@
 #ifndef WAV_H
 #define WAV_H
 
+#include <vector>
+
 // 11,025 Hz 16-bit mono audio
 class wav {
-    void allocate();
-
   public:
-    short* samples;
-    unsigned size;
+    std::vector<short> samples;
 
     // Open a wav file. The volume will be scaled based on max_volume (0.0-1.0)
     // You can skip part of the audio file by setting start and end.
     wav(const char* filename, double max_volume, int start = 0, int end = -1);
+
+    // Get the sample length
+    size_t size() const { return samples.size(); }
 
     // Loop an audio file.
     // Cut out the last n samples from the file and fade them into the first n samples.
@@ -26,12 +28,17 @@ class wav {
 
 // Contains 16-bit looping audio played back at variable speed (used for throttle engine sound)
 class wav2 {
-    short *samples, *deltas;
-    double size, playback_index;
+    std::vector<short> samples;
+    std::vector<short> deltas;
+    double playback_index;
 
   public:
     // Create a wav2 by copying the data from a wav
     wav2(wav* source);
+
+    // Get the sample length
+    size_t size() const { return samples.size(); }
+
     // Select the playback index
     void reset(double index = 0.0);
     // Advance time by "dt" samples and return the audio sample at this point in time


### PR DESCRIPTION
We drop the "const" clang-tidy check because we can always trivially add it later if we have a const object, and it doesn't play nice with the wav class