### PR TITLE
Windowed editor

### DIFF
--- a/include/editor/screen_pic.h
+++ b/include/editor/screen_pic.h
@@ -7,7 +7,13 @@ class pic8;
 
 class screen_pic {
   public:
-    screen_pic(pic8* initial);
+    enum class Mode {
+        OutsideEditor,
+        EditorGui,
+        EditorCanvas,
+    };
+
+    screen_pic(pic8* initial, Mode mode);
     void blit_to_screen(bool cursor_shape_is_x);
     pic8* pic() const { return pic_.get(); };
     void reset();
@@ -18,6 +24,7 @@ class screen_pic {
 
     pic8* initial_;
     std::unique_ptr<pic8> pic_;
+    Mode mode_;
 };
 
 #endif

--- a/include/editor/screen_pic.h
+++ b/include/editor/screen_pic.h
@@ -1,0 +1,23 @@
+#ifndef SCREEN_PIC_H
+#define SCREEN_PIC_H
+
+#include <memory>
+
+class pic8;
+
+class screen_pic {
+  public:
+    screen_pic(pic8* initial);
+    void blit_to_screen(bool cursor_shape_is_x);
+    pic8* pic() const { return pic_.get(); };
+    void reset();
+
+  private:
+    static constexpr int MIN_WIDTH = 640;
+    static constexpr int MIN_HEIGHT = 480;
+
+    pic8* initial_;
+    std::unique_ptr<pic8> pic_;
+};
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ elma_sources = files(
     'src/editor/window.cpp',
     'src/editor/tool.cpp',
     'src/editor/editor.cpp',
+    'src/editor/screen_pic.cpp',
     'src/editor/topology.cpp',
     'flagtag.cpp',
     'src/menu/ball_handler.cpp',

--- a/src/editor/dialog.cpp
+++ b/src/editor/dialog.cpp
@@ -127,17 +127,20 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
     // Draw dialog box
     int dy = 20;
     int height = text_length * dy + 50;
-    int x1 = SCREEN_WIDTH / 2 - width / 2;
-    int y1 = SCREEN_HEIGHT / 2 - height / 2;
-    int x2 = SCREEN_WIDTH / 2 + width / 2;
-    int y2 = SCREEN_HEIGHT / 2 + height / 2;
+    // Make sure x1/y1 are never negative by adjusting screen_width/screen_height
+    int screen_width = std::max(SCREEN_WIDTH, width);
+    int screen_height = std::max(SCREEN_HEIGHT, height);
+    int x1 = screen_width / 2 - width / 2;
+    int y1 = screen_height / 2 - height / 2;
+    int x2 = screen_width / 2 + width / 2;
+    int y2 = screen_height / 2 + height / 2;
     screen_pic screen = screen_pic(BufferMain);
     render_box(screen.pic(), x1, y1, x2, y2, EditorPaletteId::WINDOW,
                EditorPaletteId::WINDOW_BORDER);
 
     // Draw text
     for (int i = 0; i < text_length; i++) {
-        EditorBlackFont->write_centered(screen.pic(), SCREEN_WIDTH / 2, y1 + 22 + i * dy,
+        EditorBlackFont->write_centered(screen.pic(), screen_width / 2, y1 + 22 + i * dy,
                                         text_array[i]);
     }
 
@@ -148,16 +151,16 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
     int button_y2 = y2 - 10;
     int button_dx = 80;
     if (button_length == 1) {
-        button_array_x1[0] = SCREEN_WIDTH / 2;
+        button_array_x1[0] = screen_width / 2;
     }
     if (button_length == 2) {
-        button_array_x1[0] = SCREEN_WIDTH / 2 - button_dx / 2;
-        button_array_x1[1] = SCREEN_WIDTH / 2 + button_dx / 2;
+        button_array_x1[0] = screen_width / 2 - button_dx / 2;
+        button_array_x1[1] = screen_width / 2 + button_dx / 2;
     }
     if (button_length == 3) {
-        button_array_x1[0] = SCREEN_WIDTH / 2 - button_dx;
-        button_array_x1[1] = SCREEN_WIDTH / 2;
-        button_array_x1[2] = SCREEN_WIDTH / 2 + button_dx;
+        button_array_x1[0] = screen_width / 2 - button_dx;
+        button_array_x1[1] = screen_width / 2;
+        button_array_x1[2] = screen_width / 2 + button_dx;
     }
     if (button_length > 3) {
         internal_error("dialog button_length > 3");

--- a/src/editor/dialog.cpp
+++ b/src/editor/dialog.cpp
@@ -107,7 +107,9 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
         internal_error("dialog text_length < 1");
     }
 
+    screen_pic::Mode mode = screen_pic::Mode::EditorCanvas;
     if (!InEditor) {
+        mode = screen_pic::Mode::OutsideEditor;
         hide_cursor();
         if (is_fullscreen()) {
             MouseX = SCREEN_WIDTH / 2;
@@ -134,7 +136,7 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
     int y1 = screen_height / 2 - height / 2;
     int x2 = screen_width / 2 + width / 2;
     int y2 = screen_height / 2 + height / 2;
-    screen_pic screen = screen_pic(BufferMain);
+    screen_pic screen = screen_pic(BufferMain, mode);
     render_box(screen.pic(), x1, y1, x2, y2, EditorPaletteId::WINDOW,
                EditorPaletteId::WINDOW_BORDER);
 

--- a/src/editor/dialog.cpp
+++ b/src/editor/dialog.cpp
@@ -1,6 +1,7 @@
 #include "editor/dialog.h"
 #include "abc8.h"
 #include "editor/editor.h"
+#include "editor/screen_pic.h"
 #include "keys.h"
 #include "M_PIC.H"
 #include "main.h"
@@ -106,10 +107,7 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
         internal_error("dialog text_length < 1");
     }
 
-    // If we are in editor, keep the current mouse position, or else center the mouse
-    if (InEditor) {
-        erase_cursor();
-    } else {
+    if (!InEditor) {
         hide_cursor();
         if (is_fullscreen()) {
             MouseX = SCREEN_WIDTH / 2;
@@ -125,6 +123,7 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
         int text_width = EditorBlackFont->len(text_array[i]) + 16;
         width = std::max(width, text_width);
     }
+
     // Draw dialog box
     int dy = 20;
     int height = text_length * dy + 50;
@@ -132,11 +131,13 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
     int y1 = SCREEN_HEIGHT / 2 - height / 2;
     int x2 = SCREEN_WIDTH / 2 + width / 2;
     int y2 = SCREEN_HEIGHT / 2 + height / 2;
-    render_box(BufferMain, x1, y1, x2, y2, EditorPaletteId::WINDOW, EditorPaletteId::WINDOW_BORDER);
+    screen_pic screen = screen_pic(BufferMain);
+    render_box(screen.pic(), x1, y1, x2, y2, EditorPaletteId::WINDOW,
+               EditorPaletteId::WINDOW_BORDER);
 
     // Draw text
     for (int i = 0; i < text_length; i++) {
-        EditorBlackFont->write_centered(BufferMain, SCREEN_WIDTH / 2, y1 + 22 + i * dy,
+        EditorBlackFont->write_centered(screen.pic(), SCREEN_WIDTH / 2, y1 + 22 + i * dy,
                                         text_array[i]);
     }
 
@@ -166,20 +167,20 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
         int button_width = EditorBlackFont->len(button_array[i]) + 10;
         button_array_x2[i] = button_array_x1[i] + button_width / 2;
         button_array_x1[i] = button_array_x1[i] - button_width / 2;
-        render_box(BufferMain, button_array_x1[i], button_y1, button_array_x2[i], button_y2,
+        render_box(screen.pic(), button_array_x1[i], button_y1, button_array_x2[i], button_y2,
                    EditorPaletteId::WINDOW_BUTTON, EditorPaletteId::WINDOW_BORDER);
-        EditorBlackFont->write_centered(BufferMain, (button_array_x2[i] + button_array_x1[i]) / 2,
+        EditorBlackFont->write_centered(screen.pic(), (button_array_x2[i] + button_array_x1[i]) / 2,
                                         button_y1 + 14, button_array[i]);
     }
 
-    bltfront(BufferMain);
-    draw_cursor();
+    screen.blit_to_screen(false);
 
     // Await input
     int choice = 0;
     // Immediate exit if DIALOG_RETURN
     while (!immediately_return) {
         handle_events();
+        screen.blit_to_screen(false);
         // ESC/ENTER only valid if 1 button exists
         if (button_length == 1) {
             if (was_key_just_pressed(DIK_ESCAPE) || was_key_just_pressed(DIK_RETURN)) {
@@ -204,7 +205,6 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
         }
         // Left mouse click a button
         if (was_left_mouse_just_clicked()) {
-            update_and_draw_cursor();
             for (int i = 0; i < button_length; i++) {
                 if (MouseX >= button_array_x1[i] && MouseX <= button_array_x2[i] &&
                     MouseY >= button_y1 && MouseY <= button_y2) {
@@ -214,11 +214,9 @@ int dialog(const char* text1, const char* text2, const char* text3, const char* 
             }
             continue;
         }
-        update_and_draw_cursor();
     }
 exit:
     if (!InEditor) {
-        erase_cursor();
         show_cursor();
     }
     return choice;

--- a/src/editor/screen_pic.cpp
+++ b/src/editor/screen_pic.cpp
@@ -1,0 +1,66 @@
+#include "editor/screen_pic.h"
+#include "editor/editor.h"
+#include "main.h"
+#include "pic8.h"
+#include "M_PIC.H"
+#include "platform/implementation.h"
+#include <algorithm>
+
+screen_pic::screen_pic(pic8* initial)
+    : initial_(initial) {
+    int width = MIN_WIDTH;
+    int height = MIN_HEIGHT;
+    if (initial_) {
+        width = std::max(width, initial_->get_width());
+        height = std::max(height, initial_->get_height());
+    }
+
+    pic_ = std::make_unique<pic8>(width, height);
+
+    if (initial_) {
+        reset();
+    }
+}
+
+static void draw_cursor_pixel(pic8& surface, int x, int y) {
+    if (x < 0 || y < 0 || x >= surface.get_width() || y > surface.get_height()) {
+        return;
+    }
+    unsigned char palette_id = surface.gpixel(x, y);
+    palette_id += 128;
+    surface.ppixel(x, y, palette_id);
+}
+
+void screen_pic::blit_to_screen(bool cursor_shape_is_x) {
+    get_mouse_position(&MouseX, &MouseY);
+
+    pic8* surface = lockbackbuffer_pic(false);
+
+    blit8(surface, pic());
+
+    constexpr int CURSOR_RADIUS = 4;
+    for (int i = -CURSOR_RADIUS; i <= CURSOR_RADIUS; i++) {
+        if (cursor_shape_is_x) {
+            // Draw "x"
+            draw_cursor_pixel(*surface, MouseX + i, MouseY + i);
+            if (i != 0) {
+                draw_cursor_pixel(*surface, MouseX + i, MouseY - i);
+            }
+        } else {
+            // Draw "+"
+            draw_cursor_pixel(*surface, MouseX + i, MouseY);
+            if (i != 0) {
+                draw_cursor_pixel(*surface, MouseX, MouseY + i);
+            }
+        }
+    }
+
+    unlockbackbuffer_pic();
+}
+
+void screen_pic::reset() {
+    if (!initial_) {
+        internal_error("screen_pic::restore !initial_");
+    }
+    blit8(pic(), initial_);
+}

--- a/src/editor/screen_pic.cpp
+++ b/src/editor/screen_pic.cpp
@@ -1,4 +1,5 @@
 #include "editor/screen_pic.h"
+#include "editor/canvas.h"
 #include "editor/editor.h"
 #include "main.h"
 #include "pic8.h"
@@ -6,8 +7,25 @@
 #include "platform/implementation.h"
 #include <algorithm>
 
-screen_pic::screen_pic(pic8* initial)
-    : initial_(initial) {
+static void draw_background(pic8& pic, screen_pic::Mode mode) {
+    switch (mode) {
+    case screen_pic::Mode::OutsideEditor:
+        pic.fill_box(EditorPaletteId::BACKGROUND);
+        return;
+    case screen_pic::Mode::EditorGui:
+        pic.fill_box(EditorPaletteId::MENU);
+        return;
+    case screen_pic::Mode::EditorCanvas:
+        pic.fill_box(EditorPaletteId::BACKGROUND);
+        pic.fill_box(0, EDITOR_MENU_Y, EDITOR_MENU_X - 1, pic.get_height() - 1,
+                     EditorPaletteId::MENU);
+        return;
+    }
+}
+
+screen_pic::screen_pic(pic8* initial, Mode mode)
+    : initial_(initial),
+      mode_(mode) {
     int width = MIN_WIDTH;
     int height = MIN_HEIGHT;
     if (initial_) {
@@ -36,6 +54,7 @@ void screen_pic::blit_to_screen(bool cursor_shape_is_x) {
 
     pic8* surface = lockbackbuffer_pic(false);
 
+    draw_background(*surface, mode_);
     blit8(surface, pic());
 
     constexpr int CURSOR_RADIUS = 4;
@@ -62,5 +81,6 @@ void screen_pic::reset() {
     if (!initial_) {
         internal_error("screen_pic::restore !initial_");
     }
+    draw_background(*pic(), mode_);
     blit8(pic(), initial_);
 }


### PR DESCRIPTION
Working proof-of-concept fix to resizeable window in the editor, without rewriting the entire rendering code from the ground up.

This fix is only applied to the dialog() function at the moment

- Render to a pic8 instead of directly to the window surface. That way, when the window surface is lost, we still retain a copy that we can blit to the screen, instead of having all black
- Mouse cursor is not part of the pic8, and is only drawn directly onto the screen
- generate a generic background image when you increase the screen size so it isn't ugly (proof of concept to improve)

We enforce a minimum screen width/height so that the pictures are rendered properly when the screen size is tiny. That way, when you maximize the window again, the essential info (pop-up window and editor gui) will always be visible

```
Dumping my own TODO list here

Delete SDL_WINDOWEVENT_FOCUS_GAINED/SDL_WINDOWEVENT_FOCUS_LOST:
Remove all the unneeded references to invalidate_editor_gui() and invalidate_editor()
Fix screen border
Delete ppixelbuffer/lockfrontbuffer
```