### PR TITLE
Replay last apple time

### DIFF
--- a/include/game/recorder.h
+++ b/include/game/recorder.h
@@ -115,12 +115,12 @@ class recorder {
 
     // Find frame time of the last direction change at or before `time`,
     // detected from the flipped_bike flag in frame data.
-    // Returns -1000.0 if no direction change found.
-    double find_last_turn_frame_time(double time) const;
+    // Returns nullopt if no direction change found.
+    std::optional<double> find_last_turn_frame_time(double time) const;
 
     // Find time of the last volt (RightVolt or LeftVolt) at or before `time`.
-    // Sets `is_right_volt` to indicate direction. Returns -1000.0 if none found.
-    double find_last_volt_time(double time, bool* is_right_volt) const;
+    // Sets `is_right_volt` to indicate direction. Returns nullopt if none found.
+    std::optional<double> find_last_volt_time(double time, bool* is_right_volt) const;
 
     bool flagtag() const { return (bool)(flagtag_); };
     void set_flagtag(bool flagtag) { flagtag_ = (int)(flagtag); }

--- a/include/game/recorder.h
+++ b/include/game/recorder.h
@@ -110,8 +110,9 @@ class recorder {
     std::optional<event> recall_event(double time);
     // Walk events backward: return each event whose time > `time`, else nullopt
     std::optional<event> recall_event_reverse(double time);
-    // Returns the currently applicable gravity by iterating backwards through events
-    MotorGravity gravity(const level& lev) const;
+    // Currently applicable gravity at the current event cursor (from the last
+    // gravity apple). Returns MotorGravity::Down if none.
+    MotorGravity last_gravity(const level& lev) const;
 
     // Find frame time of the last direction change at or before `time`,
     // detected from the flipped_bike flag in frame data.

--- a/include/game/recorder.h
+++ b/include/game/recorder.h
@@ -106,10 +106,10 @@ class recorder {
     void store_frames(motorst* mot, double time, bike_sound* sound);
 
     void store_event(double time, WavEvent event_id, double volume, int object_id);
-    // Return true if a new event has occurred
-    bool recall_event(double time, WavEvent* event_id, double* volume, int* object_id);
-    // Walk events backward: returns true for each event whose time > `time`
-    bool recall_event_reverse(double time, WavEvent* event_id, double* volume, int* object_id);
+    // Return the next event at or before `time`, or nullopt if there is none
+    std::optional<event> recall_event(double time);
+    // Walk events backward: return each event whose time > `time`, else nullopt
+    std::optional<event> recall_event_reverse(double time);
     // Returns the currently applicable gravity by iterating backwards through events
     MotorGravity gravity(const level& lev) const;
 

--- a/include/game/recorder.h
+++ b/include/game/recorder.h
@@ -118,9 +118,10 @@ class recorder {
     // Returns nullopt if no direction change found.
     std::optional<double> find_last_turn_frame_time(double time) const;
 
-    // Find time of the last volt (RightVolt or LeftVolt) at or before `time`.
-    // Sets `is_right_volt` to indicate direction. Returns nullopt if none found.
-    std::optional<double> find_last_volt_time(double time, bool* is_right_volt) const;
+    // Time of the last volt (RightVolt or LeftVolt) at or before the current
+    // event cursor. Sets `is_right_volt` to indicate direction. Returns nullopt
+    // if none found.
+    std::optional<double> last_volt_time(bool* is_right_volt) const;
 
     bool flagtag() const { return (bool)(flagtag_); };
     void set_flagtag(bool flagtag) { flagtag_ = (int)(flagtag); }

--- a/include/game/recorder.h
+++ b/include/game/recorder.h
@@ -123,6 +123,10 @@ class recorder {
     // if none found.
     std::optional<double> last_volt_time(bool* is_right_volt) const;
 
+    // Time of the last apple collected at or before the current event cursor.
+    // Returns nullopt if none found.
+    std::optional<double> last_apple_time() const;
+
     bool flagtag() const { return (bool)(flagtag_); };
     void set_flagtag(bool flagtag) { flagtag_ = (int)(flagtag); }
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -671,8 +671,7 @@ static void rewind_override_animations(driver& driv, double time) {
     }
     metadata->camera_turning.flipped = flipped_camera;
 
-    metadata->volt_time =
-        rec->find_last_volt_time(time, &metadata->volt_is_right).value_or(-1000.0);
+    metadata->volt_time = rec->last_volt_time(&metadata->volt_is_right).value_or(-1000.0);
 }
 
 // Load replay data (instead of simulating bike physics)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -646,6 +646,8 @@ static void reverse_events(driver& driv, double time) {
             obj->active = true;
             mot->apple_count--;
 
+            mot->last_apple_time = (int)(rec->last_apple_time().value_or(0) * TIME_TO_CENTISECONDS);
+
             if (obj->gravity()) {
                 mot->gravity_direction = rec->gravity(*Level);
             }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -634,14 +634,11 @@ static void reverse_events(driver& driv, double time) {
     motorst* mot = driv.mot;
     recorder* rec = driv.rec;
 
-    WavEvent wav;
-    double vol;
-    int obj_id;
-    while (rec->recall_event_reverse(time, &wav, &vol, &obj_id)) {
-        if (obj_id < 0) {
+    while (std::optional<event> ev = rec->recall_event_reverse(time)) {
+        if (ev->object_id < 0) {
             continue;
         }
-        object* obj = Level->objects[obj_id];
+        object* obj = Level->objects[ev->object_id];
         if (obj && obj->type == object::Type::Food) {
             obj->active = true;
             mot->apple_count--;
@@ -690,23 +687,20 @@ static bool replay_frame(driver& driv, double time, bool* other_draw_view) {
     set_head_position(mot);
 
     // Play events
-    WavEvent wav_id;
-    double volume;
-    int object_id;
-    while (rec->recall_event(time, &wav_id, &volume, &object_id)) {
-        if (object_id >= 0) {
+    while (std::optional<event> ev = rec->recall_event(time)) {
+        if (ev->object_id >= 0) {
             int prev_apple_count = mot->apple_count;
-            handle_object_interaction(driv, object_id);
+            handle_object_interaction(driv, ev->object_id);
             if (prev_apple_count < mot->apple_count) {
                 mot->last_apple_time = (int)(time * TIME_TO_CENTISECONDS);
             }
         } else {
-            start_wav(wav_id, volume);
-            if (wav_id == WavEvent::RightVolt) {
+            start_wav(ev->event_id, ev->volume);
+            if (ev->event_id == WavEvent::RightVolt) {
                 metadata->volt_is_right = true;
                 metadata->volt_time = time;
             }
-            if (wav_id == WavEvent::LeftVolt) {
+            if (ev->event_id == WavEvent::LeftVolt) {
                 metadata->volt_is_right = false;
                 metadata->volt_time = time;
             }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -692,7 +692,7 @@ static bool replay_frame(driver& driv, double time, bool* other_draw_view) {
             int prev_apple_count = mot->apple_count;
             handle_object_interaction(driv, ev->object_id);
             if (prev_apple_count < mot->apple_count) {
-                mot->last_apple_time = (int)(time * TIME_TO_CENTISECONDS);
+                mot->last_apple_time = (int)(ev->time * TIME_TO_CENTISECONDS);
             }
         } else {
             start_wav(ev->event_id, ev->volume);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -646,7 +646,7 @@ static void reverse_events(driver& driv, double time) {
             mot->last_apple_time = (int)(rec->last_apple_time().value_or(0) * TIME_TO_CENTISECONDS);
 
             if (obj->gravity()) {
-                mot->gravity_direction = rec->gravity(*Level);
+                mot->gravity_direction = rec->last_gravity(*Level);
             }
         }
     }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -660,7 +660,7 @@ static void rewind_override_animations(driver& driv, double time) {
     motorst* mot = driv.mot;
     recorder* rec = driv.rec;
 
-    double turn_time = rec->find_last_turn_frame_time(time);
+    double turn_time = rec->find_last_turn_frame_time(time).value_or(-1000.0);
     metadata->bike_turning.flipped = mot->flipped_bike;
     metadata->bike_turning.turn_time = turn_time;
 
@@ -671,7 +671,8 @@ static void rewind_override_animations(driver& driv, double time) {
     }
     metadata->camera_turning.flipped = flipped_camera;
 
-    metadata->volt_time = rec->find_last_volt_time(time, &metadata->volt_is_right);
+    metadata->volt_time =
+        rec->find_last_volt_time(time, &metadata->volt_is_right).value_or(-1000.0);
 }
 
 // Load replay data (instead of simulating bike physics)

--- a/src/game/recorder.cpp
+++ b/src/game/recorder.cpp
@@ -344,7 +344,7 @@ bool recorder::recall_event(double time, WavEvent* event_id, double* volume, int
     return false;
 }
 
-double recorder::find_last_turn_frame_time(double time) const {
+std::optional<double> recorder::find_last_turn_frame_time(double time) const {
     int index = std::min((int)(TIME_TO_FRAME_INDEX * time), frame_count_ - 1);
     index = std::max(index, 0);
     bool current_flipped = (frames[index].flags >> FLAG_FLIPPED) & 1;
@@ -354,10 +354,10 @@ double recorder::find_last_turn_frame_time(double time) const {
             return (i + 1) * FRAME_INDEX_TO_TIME;
         }
     }
-    return -1000.0;
+    return std::nullopt;
 }
 
-double recorder::find_last_volt_time(double time, bool* is_right_volt) const {
+std::optional<double> recorder::find_last_volt_time(double time, bool* is_right_volt) const {
     for (int i = current_event_index - 1; i >= 0; i--) {
         if (events[i].time > time) {
             continue;
@@ -371,7 +371,7 @@ double recorder::find_last_volt_time(double time, bool* is_right_volt) const {
             return events[i].time;
         }
     }
-    return -1000.0;
+    return std::nullopt;
 }
 
 MotorGravity recorder::gravity(const level& lev) const {

--- a/src/game/recorder.cpp
+++ b/src/game/recorder.cpp
@@ -371,6 +371,15 @@ std::optional<double> recorder::last_volt_time(bool* is_right_volt) const {
     return std::nullopt;
 }
 
+std::optional<double> recorder::last_apple_time() const {
+    for (int i = current_event_index - 1; i >= 0; i--) {
+        if (events[i].event_id == WavEvent::Food) {
+            return events[i].time;
+        }
+    }
+    return std::nullopt;
+}
+
 MotorGravity recorder::gravity(const level& lev) const {
     for (int event_id = current_event_index; event_id > 0; event_id--) {
         int obj_id = events[event_id - 1].object_id;

--- a/src/game/recorder.cpp
+++ b/src/game/recorder.cpp
@@ -331,17 +331,11 @@ void recorder::store_event(double time, WavEvent event_id, double volume, int ob
     event_count++;
 }
 
-bool recorder::recall_event(double time, WavEvent* event_id, double* volume, int* object_id) {
-    if (current_event_index < event_count) {
-        if (events[current_event_index].time <= time) {
-            *event_id = events[current_event_index].event_id;
-            *volume = events[current_event_index].volume;
-            *object_id = events[current_event_index].object_id;
-            current_event_index++;
-            return true;
-        }
+std::optional<event> recorder::recall_event(double time) {
+    if (current_event_index < event_count && events[current_event_index].time <= time) {
+        return events[current_event_index++];
     }
-    return false;
+    return std::nullopt;
 }
 
 std::optional<double> recorder::find_last_turn_frame_time(double time) const {
@@ -395,16 +389,11 @@ MotorGravity recorder::gravity(const level& lev) const {
     return MotorGravity::Down;
 }
 
-bool recorder::recall_event_reverse(double time, WavEvent* event_id, double* volume,
-                                    int* object_id) {
+std::optional<event> recorder::recall_event_reverse(double time) {
     if (current_event_index > 0 && events[current_event_index - 1].time > time) {
-        current_event_index--;
-        *event_id = events[current_event_index].event_id;
-        *volume = events[current_event_index].volume;
-        *object_id = events[current_event_index].object_id;
-        return true;
+        return events[--current_event_index];
     }
-    return false;
+    return std::nullopt;
 }
 
 [[noreturn]] static void read_error(const char* filename) {

--- a/src/game/recorder.cpp
+++ b/src/game/recorder.cpp
@@ -374,9 +374,9 @@ std::optional<double> recorder::last_apple_time() const {
     return std::nullopt;
 }
 
-MotorGravity recorder::gravity(const level& lev) const {
-    for (int event_id = current_event_index; event_id > 0; event_id--) {
-        int obj_id = events[event_id - 1].object_id;
+MotorGravity recorder::last_gravity(const level& lev) const {
+    for (int i = current_event_index - 1; i >= 0; i--) {
+        int obj_id = events[i].object_id;
         if (obj_id < 0) {
             continue;
         }

--- a/src/game/recorder.cpp
+++ b/src/game/recorder.cpp
@@ -357,11 +357,8 @@ std::optional<double> recorder::find_last_turn_frame_time(double time) const {
     return std::nullopt;
 }
 
-std::optional<double> recorder::find_last_volt_time(double time, bool* is_right_volt) const {
+std::optional<double> recorder::last_volt_time(bool* is_right_volt) const {
     for (int i = current_event_index - 1; i >= 0; i--) {
-        if (events[i].time > time) {
-            continue;
-        }
         if (events[i].event_id == WavEvent::RightVolt) {
             *is_right_volt = true;
             return events[i].time;


### PR DESCRIPTION
- First commit fixes [elmadev/elma-classic#580](https://github.com/elmadev/elma-classic/issues/580).
- Second commit refactors `recall_event` to return the event, enabling the third commit.
- Third commit uses the recorded event time so the last apple time is shown accurately (and deterministically) in replays, previously it flickered between e.g. 4:37 and 4:38.
- Fourth commit is opinionated: `recorder::gravity` differing from its sibling functions for no apparent reason is confusing, so this aligns it. Also the name `gravity` is quite bad imo but I didn't change it, could also be aligned like `find_last_gravity`.