### PR TITLE
Fps/Ups combined PR

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -62,6 +62,7 @@
 * Flowers can be created/deleted in the internal editor.
 * Default foreground/background textures no longer get reset if texture not found or wrong lgr used
 * You can now individually force the foreground and background textures to "ground" and "sky", and can also set it via keybind
+* Instead of just displaying FPS, you can now display FPS (game frames), UPS (physics frames) and GPU (screen refresh rate)
 
 ## Minor Bug Fixes
 * Enforce lowercase LGR filenames to fix loading issues on case-sensitive filesystems

--- a/changelog.txt
+++ b/changelog.txt
@@ -62,7 +62,7 @@
 * Flowers can be created/deleted in the internal editor.
 * Default foreground/background textures no longer get reset if texture not found or wrong lgr used
 * You can now individually force the foreground and background textures to "ground" and "sky", and can also set it via keybind
-* Instead of just displaying FPS, you can now display FPS (game frames), UPS (physics frames) and GPU (screen refresh rate)
+* Instead of just displaying FPS, you can now display FPS (game frames; 0-1000), UPS (physics frames; 79-1000) and GPU (screen refresh rate; 0-infinity)
 
 ## Minor Bug Fixes
 * Enforce lowercase LGR filenames to fix loading issues on case-sensitive filesystems

--- a/changelog.txt
+++ b/changelog.txt
@@ -63,6 +63,7 @@
 * Default foreground/background textures no longer get reset if texture not found or wrong lgr used
 * You can now individually force the foreground and background textures to "ground" and "sky", and can also set it via keybind
 * Instead of just displaying FPS, you can now display FPS (game frames; 0-1000), UPS (physics frames; 79-1000) and GPU (screen refresh rate; 0-infinity)
+* Screen text will now always confirm if an !fps setting change is successful, instead of silently failing or succeeding if the FPS counter is hidden
 
 ## Minor Bug Fixes
 * Enforce lowercase LGR filenames to fix loading issues on case-sensitive filesystems

--- a/changelog.txt
+++ b/changelog.txt
@@ -64,6 +64,7 @@
 * You can now individually force the foreground and background textures to "ground" and "sky", and can also set it via keybind
 * Instead of just displaying FPS, you can now display FPS (game frames; 0-1000), UPS (physics frames; 79-1000) and GPU (screen refresh rate; 0-infinity)
 * Screen text will now always confirm if an !fps setting change is successful, instead of silently failing or succeeding if the FPS counter is hidden
+* Added FPS boost option to boost game FPS up to the max of 1000, regardless of your computer's processing power and screen display settings
 
 ## Minor Bug Fixes
 * Enforce lowercase LGR filenames to fix loading issues on case-sensitive filesystems

--- a/include/eol/settings.h
+++ b/include/eol/settings.h
@@ -133,6 +133,7 @@ class eol_settings {
 
     Default<bool> show_fps_{false};
     Default<bool> show_ups_{false};
+    Default<bool> show_gpu_{false};
     Clamp<int> recording_fps_{30, 30, 120};
 
     Default<bool> show_demo_menu_{true};
@@ -226,6 +227,7 @@ class eol_settings {
 
     DECLARE_FIELD_FUNCS(show_fps);
     DECLARE_FIELD_FUNCS(show_ups);
+    DECLARE_FIELD_FUNCS(show_gpu);
     DECLARE_FIELD_FUNCS(recording_fps);
 
     DECLARE_FIELD_FUNCS(show_demo_menu);

--- a/include/eol/settings.h
+++ b/include/eol/settings.h
@@ -134,6 +134,8 @@ class eol_settings {
     Default<bool> show_fps_{false};
     Default<bool> show_ups_{false};
     Default<bool> show_gpu_{false};
+    Default<bool> fps_limit_enabled_{false};
+    Clamp<int> fps_limit_{30, 100, 1000};
     Clamp<int> recording_fps_{30, 30, 120};
 
     Default<bool> show_demo_menu_{true};
@@ -228,6 +230,8 @@ class eol_settings {
     DECLARE_FIELD_FUNCS(show_fps);
     DECLARE_FIELD_FUNCS(show_ups);
     DECLARE_FIELD_FUNCS(show_gpu);
+    DECLARE_FIELD_FUNCS(fps_limit_enabled);
+    DECLARE_FIELD_FUNCS(fps_limit);
     DECLARE_FIELD_FUNCS(recording_fps);
 
     DECLARE_FIELD_FUNCS(show_demo_menu);

--- a/include/eol/settings.h
+++ b/include/eol/settings.h
@@ -136,6 +136,7 @@ class eol_settings {
     Default<bool> show_gpu_{false};
     Default<bool> fps_limit_enabled_{false};
     Clamp<int> fps_limit_{30, 100, 1000};
+    Default<bool> fps_boost_{false};
     Clamp<int> recording_fps_{30, 30, 120};
 
     Default<bool> show_demo_menu_{true};
@@ -232,6 +233,7 @@ class eol_settings {
     DECLARE_FIELD_FUNCS(show_gpu);
     DECLARE_FIELD_FUNCS(fps_limit_enabled);
     DECLARE_FIELD_FUNCS(fps_limit);
+    DECLARE_FIELD_FUNCS(fps_boost);
     DECLARE_FIELD_FUNCS(recording_fps);
 
     DECLARE_FIELD_FUNCS(show_demo_menu);

--- a/include/game/driver.h
+++ b/include/game/driver.h
@@ -41,6 +41,7 @@ struct driver {
     bool dead = false;
     int finish_time = 0;
     bool draw_view = true;
+    bool one_frame_brake_pending = false; // sticky one-frame-brake latch needed with fps limiter
 
     driver(motorst* mot, recorder* rec, player_keys* keys, hud_visibility* hud);
     void reset_metadata();

--- a/include/game/fps.h
+++ b/include/game/fps.h
@@ -1,6 +1,8 @@
 #ifndef GAME_FPS_H
 #define GAME_FPS_H
 
+#include <string>
+
 namespace fps {
 
 void reset();
@@ -8,8 +10,8 @@ void reset();
 void count_fps();
 void count_ups();
 
-double fps();
-double ups();
+std::string format_fps();
+std::string format_ups();
 
 } // namespace fps
 

--- a/include/game/fps.h
+++ b/include/game/fps.h
@@ -9,9 +9,11 @@ void reset();
 
 void count_fps();
 void count_ups();
+void count_gpu();
 
 std::string format_fps();
 std::string format_ups();
+std::string format_gpu();
 
 } // namespace fps
 

--- a/include/main.h
+++ b/include/main.h
@@ -18,6 +18,7 @@ using recname = char[MAX_REPLAY_EXT_LEN + 1];
 using recpath = char[MAX_REPLAY_PATH_LEN + 1];
 
 constexpr double STOPWATCH_MULTIPLIER = 0.182;
+constexpr double STOPWATCH_TO_PHYS_TIME = 0.0024;
 extern bool ErrorGraphicsLoaded;
 
 [[noreturn]] void quit();

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -1,8 +1,11 @@
 #ifndef EOL_PACER_H
 #define EOL_PACER_H
 
+#include "main.h"
+
 namespace pacer {
 
+constexpr double MILLISECONDS_TO_PHYS_TIME = STOPWATCH_MULTIPLIER * STOPWATCH_TO_PHYS_TIME;
 constexpr double PHYS_MAX_TIMESTEP = 0.0055;
 
 // Will be updated on the next run

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -5,6 +5,9 @@ namespace pacer {
 
 constexpr double PHYS_MAX_TIMESTEP = 0.0055;
 
+// Will be updated on the next run
+void request_fps_limit(bool enabled, int limit);
+
 void reset();
 
 void new_frame();

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -8,6 +8,9 @@ namespace pacer {
 constexpr double MILLISECONDS_TO_PHYS_TIME = STOPWATCH_MULTIPLIER * STOPWATCH_TO_PHYS_TIME;
 constexpr double PHYS_MAX_TIMESTEP = 0.0055;
 
+// Returns string showing current and next FPS limit
+std::string format_fps_limit();
+
 // Will be updated on the next run
 void request_fps_limit(bool enabled, int limit);
 

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -1,0 +1,16 @@
+#ifndef EOL_PACER_H
+#define EOL_PACER_H
+
+namespace pacer {
+
+constexpr double PHYS_MAX_TIMESTEP = 0.0055;
+
+void reset();
+
+void new_frame();
+
+bool subframe(double* out_dt);
+
+} // namespace pacer
+
+#endif

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -12,6 +12,9 @@ constexpr double PHYS_MAX_TIMESTEP = 0.0055;
 std::string format_fps_limit();
 
 // Will be updated on the next run
+void toggle_fps_boost();
+
+// Will be updated on the next run
 void request_fps_limit(bool enabled, int limit);
 
 void reset();

--- a/include/renderer/timer.h
+++ b/include/renderer/timer.h
@@ -5,7 +5,8 @@
 
 class pic8;
 
-constexpr double TIME_TO_CENTISECONDS = 100.0 / (STOPWATCH_MULTIPLIER * 1000.0 * 0.0024);
+constexpr double TIME_TO_CENTISECONDS =
+    100.0 / (STOPWATCH_MULTIPLIER * 1000.0 * STOPWATCH_TO_PHYS_TIME);
 
 void draw_timers(const char* best_time_text, double flag_tag_time, double current_time, pic8* dest,
                  int dest_width, int dest_height);

--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,7 @@ elma_sources = files(
     'src/physics/forces.cpp',
     'src/physics/init.cpp',
     'src/physics/move.cpp',
+    'src/physics/pacer.cpp',
     'src/pic/abc8.cpp',
     'src/pic/anim.cpp',
     'src/pic/lgr.cpp',

--- a/src/eol/console.cpp
+++ b/src/eol/console.cpp
@@ -3,6 +3,7 @@
 #include "eol/settings.h"
 #include "eol/status_messages.h"
 #include "log.h"
+#include "physics/pacer.h"
 #include "pic/abc8.h"
 #include "platform/implementation.h"
 #include "platform/scancode.h"
@@ -92,6 +93,31 @@ void console::register_console_commands() {
     REGISTER_SETTINGS_BOOL(show_gravity_arrows);
 
     REGISTER_SETTINGS_BOOL(show_fps);
+
+    // eol-client !fps aggregate:
+    //   fps         -> toggle show_fps
+    //   fps on/off  -> queue limit on/off
+    //   fps <N>     -> queue numeric limit on
+    register_command("fps", [](std::string_view text) {
+        if (text.empty()) {
+            EolSettings->set_show_fps(!EolSettings->show_fps());
+            StatusMessages->add(EolSettings->show_fps() ? "FPS info shown" : "FPS info hidden");
+            return;
+        }
+        std::string s(text);
+        if (strcmpi(s.c_str(), "on") == 0) {
+            pacer::request_fps_limit(true, EolSettings->fps_limit());
+        } else if (strcmpi(s.c_str(), "off") == 0) {
+            pacer::request_fps_limit(false, EolSettings->fps_limit());
+        } else {
+            char* end = nullptr;
+            int fps = (int)std::strtol(s.c_str(), &end, 10);
+            if (end != s.c_str() && fps >= 30 && fps <= 1000) {
+                pacer::request_fps_limit(true, fps);
+            }
+        }
+    });
+
     REGISTER_SETTINGS_BOOL(show_ups);
     REGISTER_SETTINGS_BOOL(show_gpu);
     register_alias("ups", "show_ups");

--- a/src/eol/console.cpp
+++ b/src/eol/console.cpp
@@ -93,7 +93,9 @@ void console::register_console_commands() {
 
     REGISTER_SETTINGS_BOOL(show_fps);
     REGISTER_SETTINGS_BOOL(show_ups);
+    REGISTER_SETTINGS_BOOL(show_gpu);
     register_alias("ups", "show_ups");
+    register_alias("gpu", "show_gpu");
 
     REGISTER_SETTINGS_BOOL(cripple_no_brake);
     register_alias("nobrake", "cripple_no_brake");

--- a/src/eol/console.cpp
+++ b/src/eol/console.cpp
@@ -93,7 +93,6 @@ void console::register_console_commands() {
     REGISTER_SETTINGS_BOOL(show_gravity_arrows);
 
     REGISTER_SETTINGS_BOOL(show_fps);
-
     // eol-client !fps aggregate:
     //   fps         -> toggle show_fps
     //   fps on/off  -> queue limit on/off
@@ -105,7 +104,9 @@ void console::register_console_commands() {
             return;
         }
         std::string s(text);
-        if (strcmpi(s.c_str(), "on") == 0) {
+        if (strcmpi(s.c_str(), "boost") == 0) {
+            pacer::toggle_fps_boost();
+        } else if (strcmpi(s.c_str(), "on") == 0) {
             pacer::request_fps_limit(true, EolSettings->fps_limit());
         } else if (strcmpi(s.c_str(), "off") == 0) {
             pacer::request_fps_limit(false, EolSettings->fps_limit());

--- a/src/eol/settings.cpp
+++ b/src/eol/settings.cpp
@@ -198,6 +198,7 @@ void eol_settings::set_show_gravity_arrows(bool b) { show_gravity_arrows_ = b; }
 
 void eol_settings::set_show_fps(bool show) { show_fps_ = show; }
 void eol_settings::set_show_ups(bool show) { show_ups_ = show; }
+void eol_settings::set_show_gpu(bool show) { show_gpu_ = show; }
 void eol_settings::set_recording_fps(int fps) { recording_fps_ = fps; }
 
 void eol_settings::set_show_demo_menu(bool show) { show_demo_menu_ = show; }
@@ -424,6 +425,7 @@ void from_json(const json& j, combo_scancode& r) { r = combo_scancode((unsigned 
                                                                                                    \
     JSON_FIELD(show_fps)                                                                           \
     JSON_FIELD(show_ups)                                                                           \
+    JSON_FIELD(show_gpu)                                                                           \
     JSON_FIELD(recording_fps)                                                                      \
                                                                                                    \
     JSON_FIELD(show_demo_menu)                                                                     \

--- a/src/eol/settings.cpp
+++ b/src/eol/settings.cpp
@@ -201,6 +201,7 @@ void eol_settings::set_show_ups(bool show) { show_ups_ = show; }
 void eol_settings::set_show_gpu(bool show) { show_gpu_ = show; }
 void eol_settings::set_fps_limit_enabled(bool b) { fps_limit_enabled_ = b; }
 void eol_settings::set_fps_limit(int fps) { fps_limit_ = fps; }
+void eol_settings::set_fps_boost(bool b) { fps_boost_ = b; }
 void eol_settings::set_recording_fps(int fps) { recording_fps_ = fps; }
 
 void eol_settings::set_show_demo_menu(bool show) { show_demo_menu_ = show; }
@@ -430,6 +431,7 @@ void from_json(const json& j, combo_scancode& r) { r = combo_scancode((unsigned 
     JSON_FIELD(show_gpu)                                                                           \
     JSON_FIELD(fps_limit_enabled)                                                                  \
     JSON_FIELD(fps_limit)                                                                          \
+    JSON_FIELD(fps_boost)                                                                          \
     JSON_FIELD(recording_fps)                                                                      \
                                                                                                    \
     JSON_FIELD(show_demo_menu)                                                                     \

--- a/src/eol/settings.cpp
+++ b/src/eol/settings.cpp
@@ -199,6 +199,8 @@ void eol_settings::set_show_gravity_arrows(bool b) { show_gravity_arrows_ = b; }
 void eol_settings::set_show_fps(bool show) { show_fps_ = show; }
 void eol_settings::set_show_ups(bool show) { show_ups_ = show; }
 void eol_settings::set_show_gpu(bool show) { show_gpu_ = show; }
+void eol_settings::set_fps_limit_enabled(bool b) { fps_limit_enabled_ = b; }
+void eol_settings::set_fps_limit(int fps) { fps_limit_ = fps; }
 void eol_settings::set_recording_fps(int fps) { recording_fps_ = fps; }
 
 void eol_settings::set_show_demo_menu(bool show) { show_demo_menu_ = show; }
@@ -426,6 +428,8 @@ void from_json(const json& j, combo_scancode& r) { r = combo_scancode((unsigned 
     JSON_FIELD(show_fps)                                                                           \
     JSON_FIELD(show_ups)                                                                           \
     JSON_FIELD(show_gpu)                                                                           \
+    JSON_FIELD(fps_limit_enabled)                                                                  \
+    JSON_FIELD(fps_limit)                                                                          \
     JSON_FIELD(recording_fps)                                                                      \
                                                                                                    \
     JSON_FIELD(show_demo_menu)                                                                     \

--- a/src/game/fps.cpp
+++ b/src/game/fps.cpp
@@ -1,5 +1,6 @@
 #include "game/fps.h"
 #include "platform/implementation.h"
+#include <format>
 
 namespace {
 
@@ -12,13 +13,20 @@ double prev_fps;
 double prev_ups;
 long long prev_time;
 
+std::string format_value(double value) {
+    if (value == 0.0) {
+        return "";
+    }
+    return std::format("{:.0f}", value);
+}
+
 } // namespace
 
 namespace fps {
 
-double fps() { return prev_fps; }
+std::string format_fps() { return format_value(prev_fps); }
 
-double ups() { return prev_ups; }
+std::string format_ups() { return format_value(prev_ups); }
 
 void reset() {
     frame_count = 0;

--- a/src/game/fps.cpp
+++ b/src/game/fps.cpp
@@ -9,8 +9,10 @@ constexpr long long UPDATE_INTERVAL = 1000;
 
 int frame_count;
 int update_count;
+int render_count;
 double prev_fps;
 double prev_ups;
+double prev_gpu;
 long long prev_time;
 
 std::string format_value(double value) {
@@ -28,11 +30,15 @@ std::string format_fps() { return format_value(prev_fps); }
 
 std::string format_ups() { return format_value(prev_ups); }
 
+double gpu() { return prev_gpu; }
+
 void reset() {
     frame_count = 0;
     update_count = 0;
+    render_count = 0;
     prev_fps = 0.0;
     prev_ups = 0.0;
+    prev_gpu = 0.0;
     prev_time = get_milliseconds();
 }
 
@@ -48,8 +54,10 @@ static void calculate() {
     if (dt >= update_interval) {
         prev_fps = 1000.0 * frame_count / dt;
         prev_ups = 1000.0 * update_count / dt;
+        prev_gpu = 1000.0 * render_count / dt;
         frame_count = 0;
         update_count = 0;
+        render_count = 0;
         prev_time = current_time;
     }
 }
@@ -61,5 +69,7 @@ void count_fps() {
 }
 
 void count_ups() { update_count++; }
+
+void count_gpu() { render_count++; }
 
 } // namespace fps

--- a/src/game/fps.cpp
+++ b/src/game/fps.cpp
@@ -62,14 +62,14 @@ static void calculate() {
     }
 }
 
-void count_fps() {
-    frame_count++;
-
-    calculate();
-}
+void count_fps() { frame_count++; }
 
 void count_ups() { update_count++; }
 
-void count_gpu() { render_count++; }
+void count_gpu() {
+    render_count++;
+
+    calculate();
+}
 
 } // namespace fps

--- a/src/game/fps.cpp
+++ b/src/game/fps.cpp
@@ -30,7 +30,7 @@ std::string format_fps() { return format_value(prev_fps); }
 
 std::string format_ups() { return format_value(prev_ups); }
 
-double gpu() { return prev_gpu; }
+std::string format_gpu() { return format_value(prev_gpu); }
 
 void reset() {
     frame_count = 0;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -485,8 +485,6 @@ int game_loop(const char* filename, CameraMode camera_mode) {
         EolClient->enter_level(filename, Level, camera_mode == CameraMode::MapViewer);
     }
 
-    stopwatch_reset();
-
     driver driv1(Motor1, Rec1, &State->keys1, &HudGame1);
     driver driv2(Motor2, Rec2, &State->keys2, &HudGame2);
 
@@ -517,17 +515,15 @@ int game_loop(const char* filename, CameraMode camera_mode) {
         const bool frozen = time == 0.0 && current_camera.mode != CameraMode::MapViewer &&
                             EolClient->bike_frozen_by_countdown();
         if (frozen) {
-            stopwatch_reset();
             pacer::reset();
-        } else {
-            pacer::new_frame();
         }
 
         handle_events();
+
         bool console_was_active = handle_console_input();
 
         if (!frozen) {
-            bool counted_fps = false;
+            pacer::new_frame();
 
             double dt = 0.0;
             while (pacer::subframe(&dt)) {
@@ -537,10 +533,6 @@ int game_loop(const char* filename, CameraMode camera_mode) {
                     continue;
                 }
 
-                if (!counted_fps) {
-                    fps::count_fps();
-                    counted_fps = true;
-                }
                 fps::count_ups();
 
                 if (!driv1.dead) {
@@ -811,7 +803,7 @@ int replay_loop(const char* filename, bool restore_player_visibility) {
 
         // Get timestep
         double now = stopwatch();
-        double dt = (now - last_stopwatch) * 0.0024;
+        double dt = (now - last_stopwatch) * STOPWATCH_TO_PHYS_TIME;
         last_stopwatch = now;
 
         double speed = 1.0;
@@ -980,7 +972,7 @@ void render_replay(const char* level_filename) {
             break;
         }
 
-        double time = (double)VideoFrameIndex * (STOPWATCH_MULTIPLIER * 1000.0 * 0.0024) /
+        double time = (double)VideoFrameIndex * (pacer::MILLISECONDS_TO_PHYS_TIME * 1000.0) /
                       EolSettings->recording_fps();
 
         bool finished1 = !replay_frame(driv1, time, &driv2.draw_view);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -13,6 +13,7 @@
 #include "physics/flagtag.h"
 #include "physics/forces.h"
 #include "physics/init.h"
+#include "physics/pacer.h"
 #include "pic/lgr.h"
 #include "platform/implementation.h"
 #include "platform/scancode.h"
@@ -445,6 +446,8 @@ static void setup_gameloop(const char* filename) {
 
     OutOfBounds = false;
 
+    pacer::reset();
+
     Lgr->pal->set();
 }
 
@@ -515,25 +518,19 @@ int game_loop(const char* filename, CameraMode camera_mode) {
                             EolClient->bike_frozen_by_countdown();
         if (frozen) {
             stopwatch_reset();
+            pacer::reset();
+        } else {
+            pacer::new_frame();
         }
 
-        // Get timestep
-        double target_time = stopwatch() * 0.0024;
-        target_time = std::max(0.000001, target_time);
-
         handle_events();
-
         bool console_was_active = handle_console_input();
 
         if (!frozen) {
             bool counted_fps = false;
-            while (time <= target_time - 0.000001) {
-                // Cap slowest frame to 0.0055 (approximately 12.6 milliseconds or 79.4 fps)
-                double dt = 0.0055;
-                if (time + dt > target_time) {
-                    dt = target_time - time;
-                }
 
+            double dt = 0.0;
+            while (pacer::subframe(&dt)) {
                 if (current_camera.mode == CameraMode::MapViewer) {
                     update_freecam(dt, current_camera);
                     time += dt;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -526,6 +526,7 @@ int game_loop(const char* filename, CameraMode camera_mode) {
         bool console_was_active = handle_console_input();
 
         if (!frozen) {
+            bool counted_fps = false;
             while (time <= target_time - 0.000001) {
                 // Cap slowest frame to 0.0055 (approximately 12.6 milliseconds or 79.4 fps)
                 double dt = 0.0055;
@@ -539,7 +540,12 @@ int game_loop(const char* filename, CameraMode camera_mode) {
                     continue;
                 }
 
+                if (!counted_fps) {
+                    fps::count_fps();
+                    counted_fps = true;
+                }
                 fps::count_ups();
+
                 if (!driv1.dead) {
                     physics_subframe(driv1, time, dt);
                 }

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -63,6 +63,16 @@ template <typename Scancode> static bool was_game_key_just_pressed(Scancode code
     return was_key_just_pressed(code);
 }
 
+// Latch a one-frame-brake key press onto the driver. was_just_pressed for one_frame_brake fires
+// for only one outer iter; at low fps_limit that iter rarely lines up with a sub-step actually
+// firing, so without this latch ~95% of presses miss. Called every outer iter so the press
+// survives until physics_subframe consumes (ORs into is_brake_down and clears) it.
+static void latch_one_frame_brake(driver& driv) {
+    if (was_game_key_just_pressed(driv.keys->one_frame_brake)) {
+        driv.one_frame_brake_pending = true;
+    }
+}
+
 static void update_freecam(double dt, camera& current_camera) {
     double speed = 30.0;
     if (is_game_key_down(DIK_LSHIFT) || is_game_key_down(DIK_RSHIFT)) {
@@ -142,7 +152,8 @@ static void physics_subframe(driver& driv, double time, double dt) {
     // Adjust key inputs to only allow valid inputs, accounting for volt delay and cripples
     bool is_gas_down = is_game_key_down(keys->gas);
     bool is_brake_down = is_game_key_down(keys->brake) || is_game_key_down(keys->brake_alias) ||
-                         was_game_key_just_pressed(keys->one_frame_brake);
+                         driv.one_frame_brake_pending;
+    driv.one_frame_brake_pending = false;
     bool is_right_volt_down = is_game_key_down(keys->right_volt);
     bool is_left_volt_down = is_game_key_down(keys->left_volt);
 
@@ -523,6 +534,13 @@ int game_loop(const char* filename, CameraMode camera_mode) {
         bool console_was_active = handle_console_input();
 
         if (!frozen) {
+            // Latch one-frame-brake AFTER console toggle so a same-iter console close releases the
+            // brake key into the latch as expected.
+            latch_one_frame_brake(driv1);
+            if (!Single) {
+                latch_one_frame_brake(driv2);
+            }
+
             pacer::new_frame();
 
             double dt = 0.0;

--- a/src/game/recorder.cpp
+++ b/src/game/recorder.cpp
@@ -20,7 +20,8 @@ bool MergedRec = false;
 constexpr int MAGIC_NUMBER = 4796277;
 
 constexpr int FRAME_RATE = 30;
-constexpr double TIME_TO_FRAME_INDEX = FRAME_RATE / (STOPWATCH_MULTIPLIER * 1000.0 * 0.0024);
+constexpr double TIME_TO_FRAME_INDEX =
+    FRAME_RATE / (STOPWATCH_MULTIPLIER * 1000.0 * STOPWATCH_TO_PHYS_TIME);
 constexpr double FRAME_INDEX_TO_TIME = 1.0 / TIME_TO_FRAME_INDEX;
 
 constexpr int INITIAL_FRAMES = FRAME_RATE * 60 * 60; // 30 fps * 60 sec * 60 min

--- a/src/menu/options.cpp
+++ b/src/menu/options.cpp
@@ -454,6 +454,7 @@ void menu_options() {
                 static constexpr int steps[] = {60, 100, 144, 240, 500};
                 if (!EolSettings->fps_limit_enabled_persisted()) {
                     EolSettings->persist_fps_limit_enabled(true);
+                    EolSettings->persist_fps_boost(false);
                     EolSettings->persist_fps_limit(steps[0]);
                     return;
                 }
@@ -466,6 +467,15 @@ void menu_options() {
                 }
                 EolSettings->persist_fps_limit_enabled(false);
                 EolSettings->persist_fps_limit(steps[0]);
+            });
+
+        nav.add_row(
+            "Simulate Max FPS:", EolSettings->fps_boost_persisted() ? "Yes" : "No", NAV_FUNC() {
+                bool enabled = !EolSettings->fps_boost_persisted();
+                EolSettings->persist_fps_boost(enabled);
+                if (enabled) {
+                    EolSettings->persist_fps_limit_enabled(false);
+                }
             });
 
         nav.add_row(

--- a/src/menu/options.cpp
+++ b/src/menu/options.cpp
@@ -443,6 +443,7 @@ void menu_options() {
 
         BOOL_OPTION("Show FPS:", show_fps);
         BOOL_OPTION("Show UPS:", show_ups);
+        BOOL_OPTION("Show GPU Framerate:", show_gpu);
 
         nav.add_row(
             "Record Replay FPS:", std::to_string(EolSettings->recording_fps_persisted()),

--- a/src/menu/options.cpp
+++ b/src/menu/options.cpp
@@ -446,6 +446,29 @@ void menu_options() {
         BOOL_OPTION("Show GPU Framerate:", show_gpu);
 
         nav.add_row(
+            "FPS Limit:",
+            EolSettings->fps_limit_enabled_persisted()
+                ? std::to_string(EolSettings->fps_limit_persisted())
+                : std::string("Off"),
+            NAV_FUNC() {
+                static constexpr int steps[] = {60, 100, 144, 240, 500};
+                if (!EolSettings->fps_limit_enabled_persisted()) {
+                    EolSettings->persist_fps_limit_enabled(true);
+                    EolSettings->persist_fps_limit(steps[0]);
+                    return;
+                }
+                int cur = EolSettings->fps_limit_persisted();
+                for (size_t i = 0; i < std::size(steps); ++i) {
+                    if (steps[i] == cur && i + 1 < std::size(steps)) {
+                        EolSettings->persist_fps_limit(steps[i + 1]);
+                        return;
+                    }
+                }
+                EolSettings->persist_fps_limit_enabled(false);
+                EolSettings->persist_fps_limit(steps[0]);
+            });
+
+        nav.add_row(
             "Record Replay FPS:", std::to_string(EolSettings->recording_fps_persisted()),
             NAV_FUNC() {
                 int old_fps = EolSettings->recording_fps_persisted();

--- a/src/menu/pic.cpp
+++ b/src/menu/pic.cpp
@@ -311,7 +311,7 @@ void menu_pic::render(bool skip_balls_helmet) {
     if (!skip_balls_helmet) {
         pic8* helmet_frame = nullptr;
         if (State->animated_menus) {
-            helmet_frame = Helmet->get_frame_by_time(time * 0.0024);
+            helmet_frame = Helmet->get_frame_by_time(time * STOPWATCH_TO_PHYS_TIME);
         } else {
             helmet_frame = Helmet->get_frame_by_index(25);
         }
@@ -411,7 +411,7 @@ bool menu_pic::render_intro_anim(double time) {
     // The helmet moves down from -SCREEN_HEIGHT to 0
     pic8* helmet_frame = nullptr;
     if (State->animated_menus) {
-        helmet_frame = Helmet->get_frame_by_time(time * 0.0024);
+        helmet_frame = Helmet->get_frame_by_time(time * STOPWATCH_TO_PHYS_TIME);
     } else {
         helmet_frame = Helmet->get_frame_by_index(25);
     }

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -44,6 +44,17 @@ std::string format_fps_limit() {
     return "";
 }
 
+void toggle_fps_boost() {
+    bool enabled = !EolSettings->fps_boost();
+    StatusMessages->add(
+        std::format("Turning FPS booster {} when the next run starts", enabled ? "on" : "off"));
+
+    EolSettings->set_fps_boost(enabled);
+    if (enabled) {
+        EolSettings->set_fps_limit_enabled(false);
+    }
+}
+
 void request_fps_limit(bool enabled, int limit) {
     bool enabled_changed =
         enabled != FpsLimitEnabled || enabled != EolSettings->fps_limit_enabled();
@@ -64,6 +75,10 @@ void request_fps_limit(bool enabled, int limit) {
     }
     EolSettings->set_fps_limit_enabled(enabled);
     EolSettings->set_fps_limit(limit);
+
+    if (enabled) {
+        EolSettings->set_fps_boost(false);
+    }
 }
 
 void reset() {

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -1,14 +1,42 @@
 #include "physics/pacer.h"
+#include "eol/settings.h"
+#include "eol/status_messages.h"
 #include "main.h"
+#include <format>
 
 namespace pacer {
 
 namespace {
 
+bool FpsLimitEnabled = false;
+int FpsLimit = 0;
+
 static double time = 0.0;
 static double target_time = 0.0;
 
 } // namespace
+
+void request_fps_limit(bool enabled, int limit) {
+    bool enabled_changed =
+        enabled != FpsLimitEnabled || enabled != EolSettings->fps_limit_enabled();
+    if (!enabled) {
+        if (enabled_changed) {
+            StatusMessages->add("Turning FPS limiter off when the next run starts");
+        } else {
+            StatusMessages->add("FPS limiter is already off");
+        }
+    } else {
+        bool limit_changed = limit != FpsLimit || limit != EolSettings->fps_limit();
+        if (enabled_changed || limit_changed) {
+            StatusMessages->add(
+                std::format("Setting FPS limiter to {} when the next run starts", limit));
+        } else {
+            StatusMessages->add(std::format("FPS is already limited to {}", limit));
+        }
+    }
+    EolSettings->set_fps_limit_enabled(enabled);
+    EolSettings->set_fps_limit(limit);
+}
 
 void reset() {
     time = 0.0;

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -4,6 +4,7 @@
 #include "game/fps.h"
 #include "main.h"
 #include "platform/implementation.h"
+#include <climits>
 #include <format>
 
 namespace pacer {
@@ -26,16 +27,34 @@ long long real_frame_count = 0;
 
 std::string format_fps_limit() {
     bool enabled = pacer::FpsLimitEnabled;
-    int limit = enabled ? pacer::FpsLimit : 0;
+    bool boost = pacer::FpsBoost;
+    int limit = 0;
+    if (enabled) {
+        limit = pacer::FpsLimit;
+    } else if (boost) {
+        limit = INT_MAX;
+    }
+
     bool next_enabled = EolSettings->fps_limit_enabled();
-    int next_limit = next_enabled ? EolSettings->fps_limit() : 0;
+    bool next_boost = EolSettings->fps_boost();
+    int next_limit = 0;
+    if (next_enabled) {
+        next_limit = EolSettings->fps_limit();
+    } else if (next_boost) {
+        next_limit = INT_MAX;
+    }
+
     auto format_limit = [](int limit) -> std::string {
         if (limit == 0) {
             return "off";
         }
+        if (limit == INT_MAX) {
+            return "^1000";
+        }
         return std::to_string(limit);
     };
-    if (enabled || next_enabled) {
+
+    if (enabled || boost || next_enabled || next_boost) {
         if (limit != next_limit) {
             return std::format(" ({} -> {})", format_limit(limit), format_limit(next_limit));
         }

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -1,7 +1,9 @@
 #include "physics/pacer.h"
 #include "eol/settings.h"
 #include "eol/status_messages.h"
+#include "game/fps.h"
 #include "main.h"
+#include "platform/implementation.h"
 #include <format>
 
 namespace pacer {
@@ -11,8 +13,13 @@ namespace {
 bool FpsLimitEnabled = false;
 int FpsLimit = 0;
 
-static double time = 0.0;
-static double target_time = 0.0;
+// In physics units of time
+double time = 0.0;
+double target_time = 0.0;
+
+// In milliseconds
+long long start_time = 0;
+long long real_frame_count = 0;
 
 } // namespace
 
@@ -41,10 +48,32 @@ void request_fps_limit(bool enabled, int limit) {
 void reset() {
     time = 0.0;
     target_time = 0.0;
+
+    start_time = get_milliseconds();
+    real_frame_count = 0;
+
+    FpsLimitEnabled = EolSettings->fps_limit_enabled();
+    FpsLimit = EolSettings->fps_limit();
 }
 
 void new_frame() {
-    target_time = stopwatch() * 0.0024;
+    long long now = get_milliseconds();
+    long long elapsed = now - start_time;
+
+    if (FpsLimitEnabled) {
+        // In milliunits (a value of 1000 corresponds to one allowed frame)
+        long long max_allowed_frames = elapsed * FpsLimit;
+
+        if (real_frame_count * 1000LL > max_allowed_frames) {
+            // Skip current frame
+            return;
+        }
+    }
+
+    real_frame_count++;
+    fps::count_fps();
+
+    target_time = elapsed * MILLISECONDS_TO_PHYS_TIME;
     target_time = std::max(0.000001, target_time);
 }
 

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -23,6 +23,26 @@ long long real_frame_count = 0;
 
 } // namespace
 
+std::string format_fps_limit() {
+    bool enabled = pacer::FpsLimitEnabled;
+    int limit = enabled ? pacer::FpsLimit : 0;
+    bool next_enabled = EolSettings->fps_limit_enabled();
+    int next_limit = next_enabled ? EolSettings->fps_limit() : 0;
+    auto format_limit = [](int limit) -> std::string {
+        if (limit == 0) {
+            return "off";
+        }
+        return std::to_string(limit);
+    };
+    if (enabled || next_enabled) {
+        if (limit != next_limit) {
+            return std::format(" ({} -> {})", format_limit(limit), format_limit(next_limit));
+        }
+        return std::format(" ({})", format_limit(limit));
+    }
+    return "";
+}
+
 void request_fps_limit(bool enabled, int limit) {
     bool enabled_changed =
         enabled != FpsLimitEnabled || enabled != EolSettings->fps_limit_enabled();

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -71,10 +71,13 @@ void new_frame() {
     }
 
     real_frame_count++;
-    fps::count_fps();
 
-    target_time = elapsed * MILLISECONDS_TO_PHYS_TIME;
-    target_time = std::max(0.000001, target_time);
+    double new_time = elapsed * MILLISECONDS_TO_PHYS_TIME;
+    new_time = std::max(new_time, target_time);
+    if (new_time != target_time) {
+        fps::count_fps();
+    }
+    target_time = new_time;
 }
 
 bool subframe(double* out_dt) {

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -1,0 +1,34 @@
+#include "physics/pacer.h"
+#include "main.h"
+
+namespace pacer {
+
+namespace {
+
+static double time = 0.0;
+static double target_time = 0.0;
+
+} // namespace
+
+void reset() {
+    time = 0.0;
+    target_time = 0.0;
+}
+
+void new_frame() {
+    target_time = stopwatch() * 0.0024;
+    target_time = std::max(0.000001, target_time);
+}
+
+bool subframe(double* out_dt) {
+    double dt = target_time - time;
+    if (0.000001 > dt) {
+        return false;
+    }
+    dt = std::min(dt, PHYS_MAX_TIMESTEP);
+    *out_dt = dt;
+    time += dt;
+    return true;
+}
+
+} // namespace pacer

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -12,6 +12,7 @@ namespace {
 
 bool FpsLimitEnabled = false;
 int FpsLimit = 0;
+bool FpsBoost = false;
 
 // In physics units of time
 double time = 0.0;
@@ -74,6 +75,7 @@ void reset() {
 
     FpsLimitEnabled = EolSettings->fps_limit_enabled();
     FpsLimit = EolSettings->fps_limit();
+    FpsBoost = EolSettings->fps_boost();
 }
 
 void new_frame() {
@@ -105,7 +107,10 @@ bool subframe(double* out_dt) {
     if (0.000001 > dt) {
         return false;
     }
-    dt = std::min(dt, PHYS_MAX_TIMESTEP);
+
+    const bool boost = FpsBoost && !FpsLimitEnabled;
+    const double max_timestep = boost ? MILLISECONDS_TO_PHYS_TIME : PHYS_MAX_TIMESTEP;
+    dt = std::min(dt, max_timestep);
     *out_dt = dt;
     time += dt;
     return true;

--- a/src/pic/anim.cpp
+++ b/src/pic/anim.cpp
@@ -54,7 +54,7 @@ anim::~anim() {
 
 constexpr double FRAME_TIMESTEP = 0.014;
 
-// Input time is milliseconds*STOPWATCH_MULTIPLIER*0.0024
+// Input time is milliseconds*STOPWATCH_MULTIPLIER*STOPWATCH_TO_PHYS_TIME
 // Therefore framerate is 31.2 fps?
 pic8* anim::get_frame_by_time(double time) {
     int step = (int)(time / FRAME_TIMESTEP);

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -853,7 +853,7 @@ static void render_view(bool player1, bool bottom_player, pic8* pic, double time
 }
 
 void render_game(double time, driver& driv1, driver& driv2, camera& current_camera, GameLoop loop) {
-    fps::count_fps();
+    fps::count_gpu();
 
     // Determine who we are going to draw (player 1, player 2 or both)
     bool draw_player1 = driv1.draw_view;

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -12,6 +12,7 @@
 #include "main.h"
 #include "physics/flagtag.h"
 #include "physics/init.h"
+#include "physics/pacer.h"
 #include "pic/abc8.h"
 #include "pic/anim.h"
 #include "pic/lgr.h"
@@ -830,7 +831,7 @@ static void render_view(bool player1, bool bottom_player, pic8* pic, double time
     if (bottom_player && loop != GameLoop::Render) {
         // FPS
         if (EolSettings->show_fps()) {
-            info_rows.push_back({"FPS", fps::format_fps()});
+            info_rows.push_back({"FPS", fps::format_fps() + pacer::format_fps_limit()});
         }
 
         // UPS

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -830,23 +830,13 @@ static void render_view(bool player1, bool bottom_player, pic8* pic, double time
     if (bottom_player && loop != GameLoop::Render) {
         // FPS
         if (EolSettings->show_fps()) {
-            const double fps_value = fps::fps();
-            std::string fps_text = "";
-            if (fps_value != 0.0) {
-                fps_text = std::format("{:.0f}", fps_value);
-            }
-            info_rows.push_back({"FPS", std::move(fps_text)});
+            info_rows.push_back({"FPS", fps::format_fps()});
         }
 
         // UPS
         if (EolSettings->show_ups() && loop == GameLoop::Game &&
             current_camera.mode == CameraMode::Normal) {
-            const double ups_value = fps::ups();
-            std::string ups_text = "";
-            if (ups_value != 0.0) {
-                ups_text = std::format("{:.0f}", ups_value);
-            }
-            info_rows.push_back({"UPS", std::move(ups_text)});
+            info_rows.push_back({"UPS", fps::format_ups()});
         }
     }
 

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -834,9 +834,26 @@ static void render_view(bool player1, bool bottom_player, pic8* pic, double time
         }
 
         // UPS
-        if (EolSettings->show_ups() && loop == GameLoop::Game &&
-            current_camera.mode == CameraMode::Normal) {
-            info_rows.push_back({"UPS", fps::format_ups()});
+        bool show_ups = EolSettings->show_ups() && loop == GameLoop::Game &&
+                        current_camera.mode == CameraMode::Normal;
+        bool show_gpu = EolSettings->show_gpu();
+        std::string cpu_title = "";
+        std::string cpu_value = "";
+        if (show_gpu) {
+            cpu_title += "GPU";
+            cpu_value = fps::format_gpu();
+        }
+        if (show_ups) {
+            if (show_gpu) {
+                cpu_title += "/UPS";
+                cpu_value += "/";
+            } else {
+                cpu_title += "UPS";
+            }
+            cpu_value += fps::format_ups();
+        }
+        if (show_gpu || show_ups) {
+            info_rows.push_back({cpu_title, std::move(cpu_value)});
         }
     }
 


### PR DESCRIPTION
Here's kind of what I had in mind as a combined PR

I added UPS boost to the end of this PR just to show how it would fit in, but it wouldn't be part of the first merge

My notes for bene:

I changed the FPS limiter to use an int. We can also change it to float/double in the future, but we can never go back. So keep it an int until we decide we want it floating-point

bene's commit order is changed slightly

UPS/FPS counter and the UPS pacer are separated into two distinct files. The UPS/FPS counter is based on my PR. pacer is based on bene's PR (file moved out from eol/ to game/pacer.cpp)

Instead of using LiveFps, wanted-fps and EolSettings->fps, simplify by only using LiveFps and EolSettings->fps

Slightly change the FPS status message behaviour (change from old client):

- Even if fps info is hidden from bottom-right, still send a status message
- Even if you request the same !fps twice, still send a status message
- - If the requested fps change is identical to both the current run's fps AND the currently requested fps, tell the user he is dumb, otherwise tell the user that there will be a new fps next run

I did some cosmetic changes to the fps limiter:
- renamed some things as they made sense to me, but we can change some variable names back to benanames if you don't like the new names.
- I used long long everywhere instead of mix of uint64_t and long long