### PR TITLE
fix(platform_sdl): query display resolution for desktop fullscreen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,9 +37,9 @@ int main() {
 
     SCREEN_WIDTH = EolSettings->screen_width();
     SCREEN_HEIGHT = EolSettings->screen_height();
-    editor_canvas_update_resolution();
 
     platform_init();
+    editor_canvas_update_resolution();
 
     EolClient = new eol();
     EolClient->connect();

--- a/src/platform/sdl/sdl.cpp
+++ b/src/platform/sdl/sdl.cpp
@@ -197,6 +197,38 @@ void platform_apply_fullscreen_mode() {
     resize_renderer(SCREEN_WIDTH, SCREEN_HEIGHT);
 }
 
+// Snap the configured resolution to what the fullscreen mode will actually
+// produce, so the window is created at its final size and no resolution
+// change fires during startup, before the game is fully initialized.
+static void resolve_startup_resolution() {
+    SDL_DisplayMode mode;
+    switch (EolSettings->fullscreen()) {
+    case FullscreenMode::Windowed:
+        return;
+    case FullscreenMode::Fullscreen: {
+        SDL_DisplayMode desired = {};
+        desired.w = SCREEN_WIDTH;
+        desired.h = SCREEN_HEIGHT;
+        if (!SDL_GetClosestDisplayMode(0, &desired, &mode)) {
+            return;
+        }
+        break;
+    }
+    case FullscreenMode::FullscreenDesktop:
+        if (SDL_GetDesktopDisplayMode(0, &mode) != 0) {
+            return;
+        }
+        break;
+    }
+
+    if (mode.w != SCREEN_WIDTH || mode.h != SCREEN_HEIGHT) {
+        SCREEN_WIDTH = mode.w;
+        SCREEN_HEIGHT = mode.h;
+        EolSettings->persist_screen_width(mode.w);
+        EolSettings->persist_screen_height(mode.h);
+    }
+}
+
 void platform_init() {
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS)) {
         internal_error(SDL_GetError());
@@ -205,6 +237,7 @@ void platform_init() {
     SDL_EventState(SDL_DROPFILE, SDL_DISABLE);
     SDL_EventState(SDL_DROPTEXT, SDL_DISABLE);
 
+    resolve_startup_resolution();
     create_window(SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, SCREEN_WIDTH, SCREEN_HEIGHT);
 
     keyboard::init();

--- a/src/platform/sdl/sdl.cpp
+++ b/src/platform/sdl/sdl.cpp
@@ -183,13 +183,13 @@ void platform_apply_fullscreen_mode() {
     }
     case FullscreenMode::FullscreenDesktop: {
         SDL_SetWindowFullscreen(SDLWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
-        int w;
-        int h;
-        SDL_GetWindowSize(SDLWindow, &w, &h);
-        if (w != SCREEN_WIDTH || h != SCREEN_HEIGHT) {
-            update_resolution(w, h);
+        int display_index = SDL_GetWindowDisplayIndex(SDLWindow);
+        SDL_DisplayMode mode;
+        if (display_index >= 0 && SDL_GetDesktopDisplayMode(display_index, &mode) == 0) {
+            if (mode.w != SCREEN_WIDTH || mode.h != SCREEN_HEIGHT) {
+                update_resolution(mode.w, mode.h);
+            }
         }
-
         break;
     }
     }


### PR DESCRIPTION
On X11 the fullscreen transition is asynchronous, so querying the window size right after SDL_SetWindowFullscreen can return a stale pre-fullscreen size. The mismatch triggered an unexpected resolution change while the window was still being created. A desktop-fullscreen window always ends up at the desktop resolution, so query the display mode instead of the window size.