### PR TITLE
Fps limiter

### DIFF
--- a/include/eol/settings.h
+++ b/include/eol/settings.h
@@ -142,6 +142,8 @@ class eol_settings {
 
     Default<bool> show_fps_{false};
     Default<bool> show_ups_{false};
+    Default<bool> fps_limit_enabled_{false};
+    Clamp<int> fps_limit_{30, 100, 1000};
     Clamp<int> recording_fps_{30, 30, 120};
 
     Default<bool> show_demo_menu_{true};
@@ -246,6 +248,8 @@ class eol_settings {
 
     DECLARE_FIELD_FUNCS(show_fps);
     DECLARE_FIELD_FUNCS(show_ups);
+    DECLARE_FIELD_FUNCS(fps_limit_enabled);
+    DECLARE_FIELD_FUNCS(fps_limit);
     DECLARE_FIELD_FUNCS(recording_fps);
 
     DECLARE_FIELD_FUNCS(show_demo_menu);

--- a/include/game/fps.h
+++ b/include/game/fps.h
@@ -10,6 +10,8 @@ void reset();
 void count_fps();
 void count_ups();
 
+void update();
+
 std::string format_fps();
 std::string format_ups();
 

--- a/include/game/fps.h
+++ b/include/game/fps.h
@@ -1,6 +1,8 @@
 #ifndef GAME_FPS_H
 #define GAME_FPS_H
 
+#include <string>
+
 namespace fps {
 
 void reset();
@@ -8,8 +10,8 @@ void reset();
 void count_fps();
 void count_ups();
 
-double fps();
-double ups();
+std::string format_fps();
+std::string format_ups();
 
 } // namespace fps
 

--- a/include/main.h
+++ b/include/main.h
@@ -18,6 +18,7 @@ using recname = char[MAX_REPLAY_EXT_LEN + 1];
 using recpath = char[MAX_REPLAY_PATH_LEN + 1];
 
 constexpr double STOPWATCH_MULTIPLIER = 0.182;
+constexpr double STOPWATCH_TO_PHYS_TIME = 0.0024;
 extern bool ErrorGraphicsLoaded;
 
 [[noreturn]] void quit();

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -1,8 +1,11 @@
 #ifndef EOL_PACER_H
 #define EOL_PACER_H
 
+#include "main.h"
+
 namespace pacer {
 
+constexpr double MILLISECONDS_TO_PHYS_TIME = STOPWATCH_MULTIPLIER * STOPWATCH_TO_PHYS_TIME;
 constexpr double PHYS_MAX_TIMESTEP = 0.0055;
 
 // Will be updated on the next run

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -5,6 +5,9 @@ namespace pacer {
 
 constexpr double PHYS_MAX_TIMESTEP = 0.0055;
 
+// Will be updated on the next run
+void request_fps_limit(bool enabled, int limit);
+
 void reset();
 
 void new_frame();

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -8,6 +8,9 @@ namespace pacer {
 constexpr double MILLISECONDS_TO_PHYS_TIME = STOPWATCH_MULTIPLIER * STOPWATCH_TO_PHYS_TIME;
 constexpr double PHYS_MAX_TIMESTEP = 0.0055;
 
+// Returns string showing current and next FPS limit
+std::string format_fps_limit();
+
 // Will be updated on the next run
 void request_fps_limit(bool enabled, int limit);
 

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -1,0 +1,16 @@
+#ifndef EOL_PACER_H
+#define EOL_PACER_H
+
+namespace pacer {
+
+constexpr double PHYS_MAX_TIMESTEP = 0.0055;
+
+void reset();
+
+void new_frame();
+
+bool subframe(double* out_dt);
+
+} // namespace pacer
+
+#endif

--- a/include/renderer/timer.h
+++ b/include/renderer/timer.h
@@ -5,7 +5,8 @@
 
 class pic8;
 
-constexpr double TIME_TO_CENTISECONDS = 100.0 / (STOPWATCH_MULTIPLIER * 1000.0 * 0.0024);
+constexpr double TIME_TO_CENTISECONDS =
+    100.0 / (STOPWATCH_MULTIPLIER * 1000.0 * STOPWATCH_TO_PHYS_TIME);
 
 void draw_timers(const char* best_time_text, double flag_tag_time, double current_time, pic8* dest,
                  int dest_width, int dest_height);

--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,7 @@ elma_sources = files(
     'src/physics/forces.cpp',
     'src/physics/init.cpp',
     'src/physics/move.cpp',
+    'src/physics/pacer.cpp',
     'src/pic/abc8.cpp',
     'src/pic/anim.cpp',
     'src/pic/lgr.cpp',

--- a/src/eol/console.cpp
+++ b/src/eol/console.cpp
@@ -7,6 +7,7 @@
 #include "level/level.h"
 #include "level/object.h"
 #include "log.h"
+#include "physics/pacer.h"
 #include "pic/abc8.h"
 #include "platform/implementation.h"
 #include "platform/scancode.h"
@@ -167,6 +168,30 @@ void console::register_console_commands() {
     REGISTER_SETTINGS_INT(chat_lines);
 
     REGISTER_SETTINGS_BOOL(show_fps);
+
+    // eol-client !fps aggregate:
+    //   fps         -> toggle show_fps
+    //   fps on/off  -> queue limit on/off
+    //   fps <N>     -> queue numeric limit on
+    register_command("fps", [](std::string_view text) {
+        if (text.empty()) {
+            EolSettings->set_show_fps(!EolSettings->show_fps());
+            StatusMessages->add(EolSettings->show_fps() ? "FPS info shown" : "FPS info hidden");
+            return;
+        }
+        std::string s(text);
+        if (strcmpi(s.c_str(), "on") == 0) {
+            pacer::request_fps_limit(true, EolSettings->fps_limit());
+        } else if (strcmpi(s.c_str(), "off") == 0) {
+            pacer::request_fps_limit(false, EolSettings->fps_limit());
+        } else if (auto fps = parse_int(text); fps && *fps >= 30 && *fps <= 1000) {
+            pacer::request_fps_limit(true, *fps);
+        } else {
+            StatusMessages->add(
+                std::format("Invalid FPS: {}. Valid settings are 'on', 'off' or 30-1000", s));
+        }
+    });
+
     REGISTER_SETTINGS_BOOL(show_ups);
     register_alias("ups", "show_ups");
 

--- a/src/eol/settings.cpp
+++ b/src/eol/settings.cpp
@@ -213,6 +213,8 @@ void eol_settings::set_show_gravity_arrows(bool b) { show_gravity_arrows_ = b; }
 
 void eol_settings::set_show_fps(bool show) { show_fps_ = show; }
 void eol_settings::set_show_ups(bool show) { show_ups_ = show; }
+void eol_settings::set_fps_limit_enabled(bool b) { fps_limit_enabled_ = b; }
+void eol_settings::set_fps_limit(int fps) { fps_limit_ = fps; }
 void eol_settings::set_recording_fps(int fps) { recording_fps_ = fps; }
 
 void eol_settings::set_show_demo_menu(bool show) { show_demo_menu_ = show; }
@@ -504,6 +506,8 @@ void from_json(const json& j, combo_scancode& r) { r = combo_scancode((unsigned 
                                                                                                    \
     JSON_FIELD(show_fps)                                                                           \
     JSON_FIELD(show_ups)                                                                           \
+    JSON_FIELD(fps_limit_enabled)                                                                  \
+    JSON_FIELD(fps_limit)                                                                          \
     JSON_FIELD(recording_fps)                                                                      \
                                                                                                    \
     JSON_FIELD(show_demo_menu)                                                                     \

--- a/src/game/fps.cpp
+++ b/src/game/fps.cpp
@@ -36,7 +36,7 @@ void reset() {
     prev_time = get_milliseconds();
 }
 
-static void calculate() {
+void update() {
     long long update_interval = UPDATE_INTERVAL;
     if (prev_fps == 0.0) {
         update_interval = FIRST_UPDATE_INTERVAL;
@@ -54,11 +54,7 @@ static void calculate() {
     }
 }
 
-void count_fps() {
-    frame_count++;
-
-    calculate();
-}
+void count_fps() { frame_count++; }
 
 void count_ups() { update_count++; }
 

--- a/src/game/fps.cpp
+++ b/src/game/fps.cpp
@@ -1,5 +1,6 @@
 #include "game/fps.h"
 #include "platform/implementation.h"
+#include <format>
 
 namespace {
 
@@ -12,13 +13,20 @@ double prev_fps;
 double prev_ups;
 long long prev_time;
 
+std::string format_value(double value) {
+    if (value == 0.0) {
+        return "";
+    }
+    return std::format("{:.0f}", value);
+}
+
 } // namespace
 
 namespace fps {
 
-double fps() { return prev_fps; }
+std::string format_fps() { return format_value(prev_fps); }
 
-double ups() { return prev_ups; }
+std::string format_ups() { return format_value(prev_ups); }
 
 void reset() {
     frame_count = 0;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -551,7 +551,6 @@ int game_loop(const char* filename, CameraMode camera_mode) {
         BattleRunCripples = EolClient->battle_cripples();
     }
 
-    stopwatch_reset();
     pacer::reset();
 
     driver driv1(Motor1, Rec1, &State->keys1, &HudGame1);
@@ -584,11 +583,11 @@ int game_loop(const char* filename, CameraMode camera_mode) {
         const bool frozen = time == 0.0 && current_camera.mode != CameraMode::MapViewer &&
                             EolClient->bike_frozen_by_countdown();
         if (frozen) {
-            stopwatch_reset();
             pacer::reset();
         }
 
         handle_events();
+
         bool console_was_active = handle_console_input();
 
         if (!frozen) {

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -873,7 +873,7 @@ int replay_loop(const char* filename, bool restore_player_visibility) {
 
         // Get timestep
         double now = stopwatch();
-        double dt = (now - last_stopwatch) * 0.0024;
+        double dt = (now - last_stopwatch) * STOPWATCH_TO_PHYS_TIME;
         last_stopwatch = now;
 
         double speed = 1.0;
@@ -1042,7 +1042,7 @@ void render_replay(const char* level_filename) {
             break;
         }
 
-        double time = (double)VideoFrameIndex * (STOPWATCH_MULTIPLIER * 1000.0 * 0.0024) /
+        double time = (double)VideoFrameIndex * (pacer::MILLISECONDS_TO_PHYS_TIME * 1000.0) /
                       EolSettings->recording_fps();
 
         bool finished1 = !replay_frame(driv1, time, &driv2.draw_view);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -13,6 +13,7 @@
 #include "physics/flagtag.h"
 #include "physics/forces.h"
 #include "physics/init.h"
+#include "physics/pacer.h"
 #include "pic/lgr.h"
 #include "platform/implementation.h"
 #include "platform/scancode.h"
@@ -551,6 +552,7 @@ int game_loop(const char* filename, CameraMode camera_mode) {
     }
 
     stopwatch_reset();
+    pacer::reset();
 
     driver driv1(Motor1, Rec1, &State->keys1, &HudGame1);
     driver driv2(Motor2, Rec2, &State->keys2, &HudGame2);
@@ -583,24 +585,17 @@ int game_loop(const char* filename, CameraMode camera_mode) {
                             EolClient->bike_frozen_by_countdown();
         if (frozen) {
             stopwatch_reset();
+            pacer::reset();
         }
 
-        // Get timestep
-        double target_time = stopwatch() * 0.0024;
-        target_time = std::max(0.000001, target_time);
-
         handle_events();
-
         bool console_was_active = handle_console_input();
 
         if (!frozen) {
-            while (time <= target_time - 0.000001) {
-                // Cap slowest frame to 0.0055 (approximately 12.6 milliseconds or 79.4 fps)
-                double dt = 0.0055;
-                if (time + dt > target_time) {
-                    dt = target_time - time;
-                }
+            pacer::new_frame();
 
+            double dt = 0.0;
+            while (pacer::subframe(&dt)) {
                 if (current_camera.mode == CameraMode::MapViewer) {
                     update_freecam(dt, current_camera);
                     time += dt;

--- a/src/game/recorder.cpp
+++ b/src/game/recorder.cpp
@@ -20,7 +20,8 @@ bool MergedRec = false;
 constexpr int MAGIC_NUMBER = 4796277;
 
 constexpr int FRAME_RATE = 30;
-constexpr double TIME_TO_FRAME_INDEX = FRAME_RATE / (STOPWATCH_MULTIPLIER * 1000.0 * 0.0024);
+constexpr double TIME_TO_FRAME_INDEX =
+    FRAME_RATE / (STOPWATCH_MULTIPLIER * 1000.0 * STOPWATCH_TO_PHYS_TIME);
 constexpr double FRAME_INDEX_TO_TIME = 1.0 / TIME_TO_FRAME_INDEX;
 
 constexpr int INITIAL_FRAMES = FRAME_RATE * 60 * 60; // 30 fps * 60 sec * 60 min

--- a/src/menu/options.cpp
+++ b/src/menu/options.cpp
@@ -447,6 +447,29 @@ void menu_options() {
         BOOL_OPTION("Show UPS:", show_ups);
 
         nav.add_row(
+            "FPS Limit:",
+            EolSettings->fps_limit_enabled_persisted()
+                ? std::to_string(EolSettings->fps_limit_persisted())
+                : std::string("Off"),
+            NAV_FUNC() {
+                static constexpr int steps[] = {60, 100, 144, 240, 500};
+                if (!EolSettings->fps_limit_enabled_persisted()) {
+                    EolSettings->persist_fps_limit_enabled(true);
+                    EolSettings->persist_fps_limit(steps[0]);
+                    return;
+                }
+                int cur = EolSettings->fps_limit_persisted();
+                for (size_t i = 0; i < std::size(steps); ++i) {
+                    if (steps[i] == cur && i + 1 < std::size(steps)) {
+                        EolSettings->persist_fps_limit(steps[i + 1]);
+                        return;
+                    }
+                }
+                EolSettings->persist_fps_limit_enabled(false);
+                EolSettings->persist_fps_limit(steps[0]);
+            });
+
+        nav.add_row(
             "Record Replay FPS:", std::to_string(EolSettings->recording_fps_persisted()),
             NAV_FUNC() {
                 int old_fps = EolSettings->recording_fps_persisted();

--- a/src/menu/pic.cpp
+++ b/src/menu/pic.cpp
@@ -311,7 +311,7 @@ void menu_pic::render(bool skip_balls_helmet) {
     if (!skip_balls_helmet) {
         pic8* helmet_frame = nullptr;
         if (State->animated_menus) {
-            helmet_frame = Helmet->get_frame_by_time(time * 0.0024);
+            helmet_frame = Helmet->get_frame_by_time(time * STOPWATCH_TO_PHYS_TIME);
         } else {
             helmet_frame = Helmet->get_frame_by_index(25);
         }
@@ -411,7 +411,7 @@ bool menu_pic::render_intro_anim(double time) {
     // The helmet moves down from -SCREEN_HEIGHT to 0
     pic8* helmet_frame = nullptr;
     if (State->animated_menus) {
-        helmet_frame = Helmet->get_frame_by_time(time * 0.0024);
+        helmet_frame = Helmet->get_frame_by_time(time * STOPWATCH_TO_PHYS_TIME);
     } else {
         helmet_frame = Helmet->get_frame_by_index(25);
     }

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -26,6 +26,26 @@ long long real_frame_count = 0;
 
 } // namespace
 
+std::string format_fps_limit() {
+    bool enabled = pacer::FpsLimitEnabled;
+    int limit = enabled ? pacer::FpsLimit : 0;
+    bool next_enabled = EolSettings->fps_limit_enabled();
+    int next_limit = next_enabled ? EolSettings->fps_limit() : 0;
+    auto format_limit = [](int limit) -> std::string {
+        if (limit == 0) {
+            return "off";
+        }
+        return std::to_string(limit);
+    };
+    if (enabled || next_enabled) {
+        if (limit != next_limit) {
+            return std::format(" ({} -> {})", format_limit(limit), format_limit(next_limit));
+        }
+        return std::format(" ({})", format_limit(limit));
+    }
+    return "";
+}
+
 void request_fps_limit(bool enabled, int limit) {
     if (!EolSettings->show_fps()) {
         bool enabled_changed =

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -1,18 +1,28 @@
 #include "physics/pacer.h"
 #include "eol/settings.h"
 #include "eol/status_messages.h"
+#include "game/fps.h"
 #include "main.h"
+#include "platform/implementation.h"
 #include <format>
 
 namespace pacer {
 
 namespace {
 
+constexpr long long LIMITER_TIMEOUT_MS = 33;
+
 bool FpsLimitEnabled = false;
 int FpsLimit = 0;
 
+// In physics units of time
 double time = 0.0;
 double target_time = 0.0;
+
+// In milliseconds
+long long start_time = 0;
+long long last_real_frame_time = 0;
+long long real_frame_count = 0;
 
 } // namespace
 
@@ -43,11 +53,36 @@ void request_fps_limit(bool enabled, int limit) {
 void reset() {
     time = 0.0;
     target_time = 0.0;
+
+    start_time = get_milliseconds();
+    last_real_frame_time = start_time;
+    real_frame_count = 0;
+
+    FpsLimitEnabled = EolSettings->fps_limit_enabled();
+    FpsLimit = EolSettings->fps_limit();
 }
 
 void new_frame() {
-    target_time = stopwatch() * STOPWATCH_TO_PHYS_TIME;
-    target_time = std::max(0.000001, target_time);
+    long long now = get_milliseconds();
+    long long elapsed = now - start_time;
+
+    if (FpsLimitEnabled) {
+        // In milliunits (a value of 1000 corresponds to one allowed frame)
+        long long max_allowed_frames = elapsed * FpsLimit;
+
+        // eol-client forces a real frame at least every 33 ms even when over the limit
+        if (real_frame_count * 1000LL > max_allowed_frames &&
+            now - last_real_frame_time <= LIMITER_TIMEOUT_MS) {
+            // Skip current frame
+            return;
+        }
+    }
+
+    real_frame_count++;
+    last_real_frame_time = now;
+    fps::count_fps();
+
+    target_time = std::max(elapsed * MILLISECONDS_TO_PHYS_TIME, 0.000001);
 }
 
 bool subframe(double* out_dt) {

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -1,14 +1,44 @@
 #include "physics/pacer.h"
+#include "eol/settings.h"
+#include "eol/status_messages.h"
 #include "main.h"
+#include <format>
 
 namespace pacer {
 
 namespace {
 
+bool FpsLimitEnabled = false;
+int FpsLimit = 0;
+
 double time = 0.0;
 double target_time = 0.0;
 
 } // namespace
+
+void request_fps_limit(bool enabled, int limit) {
+    if (!EolSettings->show_fps()) {
+        bool enabled_changed =
+            enabled != FpsLimitEnabled || enabled != EolSettings->fps_limit_enabled();
+        if (!enabled) {
+            if (enabled_changed) {
+                StatusMessages->add("Turning FPS limiter off when the next run starts");
+            } else {
+                StatusMessages->add("FPS limiter is already off");
+            }
+        } else {
+            bool limit_changed = limit != FpsLimit || limit != EolSettings->fps_limit();
+            if (enabled_changed || limit_changed) {
+                StatusMessages->add(
+                    std::format("Setting FPS limiter to {} when the next run starts", limit));
+            } else {
+                StatusMessages->add(std::format("FPS is already limited to {}", limit));
+            }
+        }
+    }
+    EolSettings->set_fps_limit_enabled(enabled);
+    EolSettings->set_fps_limit(limit);
+}
 
 void reset() {
     time = 0.0;

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -1,0 +1,34 @@
+#include "physics/pacer.h"
+#include "main.h"
+
+namespace pacer {
+
+namespace {
+
+double time = 0.0;
+double target_time = 0.0;
+
+} // namespace
+
+void reset() {
+    time = 0.0;
+    target_time = 0.0;
+}
+
+void new_frame() {
+    target_time = stopwatch() * 0.0024;
+    target_time = std::max(0.000001, target_time);
+}
+
+bool subframe(double* out_dt) {
+    double dt = target_time - time;
+    if (0.000001 > dt) {
+        return false;
+    }
+    dt = std::min(dt, PHYS_MAX_TIMESTEP);
+    *out_dt = dt;
+    time += dt;
+    return true;
+}
+
+} // namespace pacer

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -46,7 +46,7 @@ void reset() {
 }
 
 void new_frame() {
-    target_time = stopwatch() * 0.0024;
+    target_time = stopwatch() * STOPWATCH_TO_PHYS_TIME;
     target_time = std::max(0.000001, target_time);
 }
 

--- a/src/pic/anim.cpp
+++ b/src/pic/anim.cpp
@@ -54,7 +54,7 @@ anim::~anim() {
 
 constexpr double FRAME_TIMESTEP = 0.014;
 
-// Input time is milliseconds*STOPWATCH_MULTIPLIER*0.0024
+// Input time is milliseconds*STOPWATCH_MULTIPLIER*STOPWATCH_TO_PHYS_TIME
 // Therefore framerate is 31.2 fps?
 pic8* anim::get_frame_by_time(double time) {
     int step = (int)(time / FRAME_TIMESTEP);

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -840,23 +840,13 @@ static void render_view(bool player1, bool bottom_player, pic8* pic, double time
     if (bottom_player && loop != GameLoop::Render) {
         // FPS
         if (EolSettings->show_fps()) {
-            const double fps_value = fps::fps();
-            std::string fps_text = "";
-            if (fps_value != 0.0) {
-                fps_text = std::format("{:.0f}", fps_value);
-            }
-            info_rows.push_back({"FPS", std::move(fps_text)});
+            info_rows.push_back({"FPS", fps::format_fps()});
         }
 
         // UPS
         if (EolSettings->show_ups() && loop == GameLoop::Game &&
             current_camera.mode == CameraMode::Normal) {
-            const double ups_value = fps::ups();
-            std::string ups_text = "";
-            if (ups_value != 0.0) {
-                ups_text = std::format("{:.0f}", ups_value);
-            }
-            info_rows.push_back({"UPS", std::move(ups_text)});
+            info_rows.push_back({"UPS", fps::format_ups()});
         }
     }
 

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -871,7 +871,7 @@ static void render_view(bool player1, bool bottom_player, pic8* pic, double time
 }
 
 void render_game(double time, driver& driv1, driver& driv2, camera& current_camera, GameLoop loop) {
-    fps::count_fps();
+    fps::update();
 
     // Determine who we are going to draw (player 1, player 2 or both)
     bool draw_player1 = driv1.draw_view;

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -822,9 +822,10 @@ static void render_view(bool player1, bool bottom_player, pic8* pic, double time
         }
         double shown_time = time;
         if (Single && EolClient->is_spying()) {
-            shown_time = spy_kuski && !EolClient->battle_hides_times()
-                             ? spy_kuski->spy_data()->time * (STOPWATCH_MULTIPLIER * 0.0024)
-                             : 0.0;
+            shown_time =
+                spy_kuski && !EolClient->battle_hides_times()
+                    ? spy_kuski->spy_data()->time * (STOPWATCH_MULTIPLIER * STOPWATCH_TO_PHYS_TIME)
+                    : 0.0;
         }
         draw_timers(BestTime, flagtag_time, shown_time, pic, GameViewWidth, GameViewHeight);
     }

--- a/src/renderer/render.cpp
+++ b/src/renderer/render.cpp
@@ -12,6 +12,7 @@
 #include "main.h"
 #include "physics/flagtag.h"
 #include "physics/init.h"
+#include "physics/pacer.h"
 #include "pic/abc8.h"
 #include "pic/anim.h"
 #include "pic/lgr.h"
@@ -841,7 +842,7 @@ static void render_view(bool player1, bool bottom_player, pic8* pic, double time
     if (bottom_player && loop != GameLoop::Render) {
         // FPS
         if (EolSettings->show_fps()) {
-            info_rows.push_back({"FPS", fps::format_fps()});
+            info_rows.push_back({"FPS", fps::format_fps() + pacer::format_fps_limit()});
         }
 
         // UPS


### PR DESCRIPTION
This is the FPS limiter from #633 with the non-eol additions removed, so we can merge a working, eol-faithful baseline first and discuss extensions (GPU display, message changes, UPS boost) separately afterwards. sunl's commits are preserved with original authorship.

Removed compared to #633:
- GPU display (show_gpu, !gpu, the GPU/UPS row); can be its own PR later
- Both changelog entries (one described features not in this PR, the other didn't match what eol actually does)

Changed compared to #633:
- Restores the 1e-6 first frame
- Restores eol's 33ms limiter timeout
- FPS in the bottom right corner shows the same value as eol; with the limiter off it can go past 1000
- Status messages behave like eol: only shown while the FPS display is hidden, since the display itself shows pending changes as (31) / (31 -> 60). eol was never silent: every `Log()` in its fps path is guarded by !ShowFPSInfo (`LimitFPS()`/`PutFPSChangePending()`), feedback just moves between the two surfaces. Not byte-identical (repeated identical !fps still re-prints where eol stays quiet), but close enough for the baseline.
- Sticky one-frame brake: this is part of eol's `LimitFPS()` itself (`ApplyOneFrameBrake` runs only on real frames); without it most one-frame-brake presses are dropped while the limiter is active
- Rewrote git history to be cleaner
- Also a theoretical issue fixed: `pacer::reset` ran before `enter_level` in #633, so lag during level entry inflated the first frame's elapsed time compared to main. It now runs where main's `stopwatch_reset` was.

Closes #633