### PR TITLE
Prevent the Lgr object from deleting/modifying data in the Level object

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -83,6 +83,7 @@
 * Foreground and background textures are previewed when selecting
 * Cursor no longer disappears when inputting a clipping or distance
 * Foreground and background textures no longer get reset if texture is not found. The lgr name will no longer be reset if lgr is not found.
+* Missing pictures, textures and masks will no longer be deleted
 * Dialog pop-ups (help, topology check, etc) are now vertically centered on the screen
 
 ## Minor Bug Fixes

--- a/changelog.txt
+++ b/changelog.txt
@@ -82,7 +82,7 @@
 ### Internal Editor Graphics
 * Foreground and background textures are previewed when selecting
 * Cursor no longer disappears when inputting a clipping or distance
-* Foreground and background textures no longer get reset if texture is not found
+* Foreground and background textures no longer get reset if texture is not found. The lgr name will no longer be reset if lgr is not found.
 * Dialog pop-ups (help, topology check, etc) are now vertically centered on the screen
 
 ## Minor Bug Fixes

--- a/changelog.txt
+++ b/changelog.txt
@@ -82,8 +82,8 @@
 ### Internal Editor Graphics
 * Foreground and background textures are previewed when selecting
 * Cursor no longer disappears when inputting a clipping or distance
-* Foreground and background textures no longer get reset if texture is not found. The lgr name will no longer be reset if lgr is not found.
-* Missing pictures, textures and masks will no longer be deleted
+* Foreground and background textures no longer get reset if texture is not found (warning only). The lgr name will no longer be reset if lgr is not found (warning only).
+* Missing pictures, textures and masks will no longer be deleted (warning only)
 * Dialog pop-ups (help, topology check, etc) are now vertically centered on the screen
 
 ## Minor Bug Fixes

--- a/changelog.txt
+++ b/changelog.txt
@@ -124,6 +124,7 @@
 * Move tool tooltip over pictures no longer occasionally shows erroneous clipping value
 * Mouse position teleporting is standardized between dragging over the top edge versus left edge
 * Changing an apple's animation number or updating the level description correctly marks the level as changed
+* Foreground and background texture menu entries are immediately updated after selecting a new LGR
 * Save As no longer sometimes silently overwrites existing files
 * Save As no longer has a buffer overflow bug
 

--- a/include/editor/topology.h
+++ b/include/editor/topology.h
@@ -1,6 +1,7 @@
 #ifndef EDITOR_TOPOLOGY_H
 #define EDITOR_TOPOLOGY_H
 
+void check_textures();
 bool check_topology(bool show_dialog);
 
 #endif

--- a/include/game/level_load.h
+++ b/include/game/level_load.h
@@ -12,6 +12,4 @@ bool load_level_play(const char* levelname);
 
 bool load_level_editor(const char* levelname);
 
-void dialog_warn_lgr_assets_deleted();
-
 #endif

--- a/include/level/level.h
+++ b/include/level/level.h
@@ -43,11 +43,10 @@ class level {
     level(const char* filename);
     ~level();
 
-    // Delete sprites that don't exist in current lgr, and make sure default ground / sky textures
-    // are different.
-    //
-    // Returns true if any sprites were deleted.
-    bool discard_missing_lgr_assets(lgrfile* lgr);
+    // For the internal editor, set the wireframe sizes for sprites based on the current lgr
+    // Optionally displays are warning if some sprites are not found in the lgr file.
+    void load_sprite_wireframes(lgrfile* lgr, bool warn_if_missing);
+
     // Get closest vertex to (x, y) in the editor, if the distance is less than 10 pixels. A polygon
     // can `skip` can be passed to skip that polygon.
     polygon* get_closest_vertex(double x, double y, int* vertex_index, double* distance = nullptr,

--- a/include/level/level.h
+++ b/include/level/level.h
@@ -25,7 +25,6 @@ class level {
 
   public:
     int level_id;
-    bool lgr_not_found;
     bool topology_errors;
     polygon* polygons[MAX_POLYGONS];
     object* objects[MAX_OBJECTS];

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -661,6 +661,8 @@ void editor() {
     invalidate_editor_gui();
     draw_editor();
 
+    check_textures();
+
     while (true) {
         handle_events();
         // Control keys
@@ -735,6 +737,7 @@ void editor() {
         } else if (i == 5 && right_click) {
             editor_help_save_and_play();
         } else if (i == 6 && left_click) {
+            check_textures();
             check_topology(true);
         } else if (i == 6 && right_click) {
             editor_help_check_topology();

--- a/src/editor/topology.cpp
+++ b/src/editor/topology.cpp
@@ -6,7 +6,38 @@
 #include "level/object.h"
 #include "level/polygon.h"
 #include "level/segments.h"
+#include "main.h"
+#include "pic/lgr.h"
+#include "platform/utils.h"
 #include <format>
+
+// Pop-up warnings without failing topology check
+void check_textures() {
+    ELMA_ASSERT(Lgr);
+    ELMA_ASSERT(Level);
+
+    // Disallow identical foreground/background textures
+    if (strcmpi(Level->foreground_name, Level->background_name) == 0) {
+        dialog("Warning: the default foreground and background textures are identical!",
+               "The incorrect textures will be loaded",
+               "Please change the foreground or background texture!");
+        return;
+    }
+
+    // Check for missing foreground texture
+    if (Lgr->get_texture_index(Level->foreground_name) < 0) {
+        dialog("Warning: the default foreground is not found!",
+               "The incorrect textures will be loaded", "Please change the foreground texture!");
+        return;
+    }
+
+    // Check for missing background texture
+    if (Lgr->get_texture_index(Level->background_name) < 0) {
+        dialog("Warning: the default background is not found!",
+               "The incorrect textures will be loaded", "Please change the background texture!");
+        return;
+    }
+}
 
 bool check_topology(bool show_dialog) {
     dialog("Checking Topology, please wait!", DIALOG_BUTTONS, DIALOG_RETURN);

--- a/src/editor/window.cpp
+++ b/src/editor/window.cpp
@@ -1542,6 +1542,10 @@ void editor_window_level_properties() {
     while (true) {
         handle_events();
         if (was_key_just_pressed(DIK_ESCAPE) || clicked_box(box_cancel)) {
+            if (strcmpi(lgr_name, Level->lgr_name) != 0) {
+                // Revert lgr back to original
+                lgrfile::load_lgr_file(Level->lgr_name);
+            }
             return;
         }
         if (was_key_just_pressed(DIK_RETURN) || clicked_box(box_ok)) {
@@ -1555,9 +1559,9 @@ void editor_window_level_properties() {
             strcpy(Level->level_name, level_name);
 
             if (strcmpi(lgr_name, Level->lgr_name) != 0) {
+                // Apply new loaded LGR
                 LevelChanged = true;
                 strcpy(Level->lgr_name, lgr_name);
-                lgrfile::load_lgr_file(Level->lgr_name);
                 Level->load_sprite_wireframes(Lgr, true);
             }
 
@@ -1587,6 +1591,7 @@ void editor_window_level_properties() {
             rerender = true;
         } else if (clicked_box(box_lgr)) {
             editor_window_choose_lgr(screen.pic(), lgr_name);
+            lgrfile::load_lgr_file(lgr_name);
             rerender = true;
         }
         if (rerender) {

--- a/src/editor/window.cpp
+++ b/src/editor/window.cpp
@@ -1174,19 +1174,17 @@ void editor_window_sprite_properties(sprite* spr) {
             Clipping default_clipping = Clipping::Unknown;
             if (spr->picture_name[0]) {
                 int index = Lgr->get_picture_index(spr->picture_name);
-                if (index < 0) {
-                    internal_error("editor_window_sprite_properties index < 0");
+                if (index >= 0) {
+                    default_distance = Lgr->pictures[index].default_distance;
+                    default_clipping = Lgr->pictures[index].default_clipping;
                 }
-                default_distance = Lgr->pictures[index].default_distance;
-                default_clipping = Lgr->pictures[index].default_clipping;
             }
             if (spr->texture_name[0]) {
                 int index = Lgr->get_texture_index(spr->texture_name);
-                if (index < 0) {
-                    internal_error("editor_window_sprite_properties index < 0");
+                if (index >= 0) {
+                    default_distance = Lgr->textures[index].default_distance;
+                    default_clipping = Lgr->textures[index].default_clipping;
                 }
-                default_distance = Lgr->textures[index].default_distance;
-                default_clipping = Lgr->textures[index].default_clipping;
             }
 
             char tmp[10];

--- a/src/editor/window.cpp
+++ b/src/editor/window.cpp
@@ -3,6 +3,7 @@
 #include "editor/dialog.h"
 #include "editor/editor.h"
 #include "editor/screen_pic.h"
+#include "editor/topology.h"
 #include "game/level_load.h"
 #include "level/level.h"
 #include "level/polygon.h"
@@ -1559,6 +1560,8 @@ void editor_window_level_properties() {
                 lgrfile::load_lgr_file(Level->lgr_name);
                 Level->load_sprite_wireframes(Lgr, true);
             }
+
+            check_textures();
             return;
         }
         if (clicked_box(box_foreground)) {

--- a/src/editor/window.cpp
+++ b/src/editor/window.cpp
@@ -1557,9 +1557,7 @@ void editor_window_level_properties() {
                 LevelChanged = true;
                 strcpy(Level->lgr_name, lgr_name);
                 lgrfile::load_lgr_file(Level->lgr_name);
-                if (Level->discard_missing_lgr_assets(Lgr)) {
-                    dialog_warn_lgr_assets_deleted();
-                }
+                Level->load_sprite_wireframes(Lgr, true);
             }
             return;
         }

--- a/src/editor/window.cpp
+++ b/src/editor/window.cpp
@@ -1212,7 +1212,7 @@ void editor_window_sprite_properties(sprite* spr) {
 
             render_box(screen.pic(), box_clipping, EditorPaletteId::WINDOW_INPUT,
                        EditorPaletteId::WINDOW_BORDER);
-            strcpy(tmp, clipping_to_string(default_clipping));
+            strcpy(tmp, clipping_to_string(clipping));
             draw_textbox_centered(screen.pic(), box_clipping, EditorPaletteId::WINDOW_INPUT, tmp);
             EditorBlackFont->write_centered(screen.pic(), x1 + 198, box_clipping.y2 + 14,
                                             "(U, S, G)");

--- a/src/game/level_load.cpp
+++ b/src/game/level_load.cpp
@@ -64,7 +64,7 @@ bool load_level_play(const char* levelname) {
         }
 
         lgrfile::load_lgr_file(Level->lgr_name);
-        Level->discard_missing_lgr_assets(Lgr);
+        Level->load_sprite_wireframes(Lgr, false);
 
         START_TIME(segments_timer);
         delete Segments;
@@ -84,9 +84,7 @@ bool load_level_play(const char* levelname) {
 bool load_level_editor(const char* levelname) {
     if (load_level(levelname)) {
         lgrfile::load_lgr_file(Level->lgr_name);
-        if (Level->discard_missing_lgr_assets(Lgr)) {
-            dialog_warn_lgr_assets_deleted();
-        }
+        Level->load_sprite_wireframes(Lgr, true);
     }
 
     // Segments are not properly updated in the editor
@@ -99,12 +97,4 @@ bool load_level_editor(const char* levelname) {
     }
 
     return true;
-}
-
-void dialog_warn_lgr_assets_deleted() {
-    dialog("The LGR file has changed since the last edition of this level and",
-           "some parts (pictures, textures or border polygons) of the level",
-           "must have been deleted!", "", "!!!!IMPORTANT!!!!",
-           "If you do not want to lose these parts, do not save this level",
-           "on its original name!");
 }

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -123,8 +123,8 @@ level::~level() {
     }
 }
 
-bool level::discard_missing_lgr_assets(lgrfile* lgr) {
-    bool sprites_deleted = false;
+void level::load_sprite_wireframes(lgrfile* lgr, bool warn_if_missing) {
+    bool missing_sprites = false;
     for (int i = 0; i < MAX_SPRITES; i++) {
         if (!sprites[i]) {
             continue;
@@ -136,17 +136,14 @@ bool level::discard_missing_lgr_assets(lgrfile* lgr) {
         spr->wireframe_height = PixelsToMeters * DEFAULT_SPRITE_WIREFRAME;
 
         if (spr->picture_name[0] && (spr->mask_name[0] || spr->texture_name[0])) {
-            internal_error("discard_missing_lgr_assets invalid pic/mask/text combination!");
+            internal_error("load_sprite_wireframes invalid pic/mask/text combination!");
         }
 
-        // Delete any sprite not existing in lgr, and also set the size of the asset
+        // Set the editor size of each sprite, and check if any sprites are missing
         if (spr->picture_name[0]) {
             int index = lgr->get_picture_index(spr->picture_name);
-            if (index < 0) {
-                spr->picture_name[0] = 0;
-                delete sprites[i];
-                sprites[i] = nullptr;
-                sprites_deleted = true;
+            if (lgr->get_picture_index(spr->picture_name) < 0) {
+                missing_sprites = true;
                 continue;
             }
 
@@ -156,10 +153,7 @@ bool level::discard_missing_lgr_assets(lgrfile* lgr) {
             if (spr->mask_name[0]) {
                 int index = lgr->get_mask_index(spr->mask_name);
                 if (index < 0) {
-                    spr->mask_name[0] = 0;
-                    delete sprites[i];
-                    sprites[i] = nullptr;
-                    sprites_deleted = true;
+                    missing_sprites = true;
                     continue;
                 }
 
@@ -167,30 +161,19 @@ bool level::discard_missing_lgr_assets(lgrfile* lgr) {
                 spr->wireframe_height = lgr->masks[index].height * PixelsToMeters;
 
                 if (spr->texture_name[0]) {
-                    int index = lgr->get_texture_index(spr->texture_name);
-                    if (index < 0) {
-                        spr->texture_name[0] = 0;
-                        delete sprites[i];
-                        sprites[i] = nullptr;
-                        sprites_deleted = true;
+                    if (lgr->get_texture_index(spr->texture_name) < 0) {
+                        missing_sprites = true;
+                        continue;
                     }
                 }
             }
         }
     }
 
-    bool sprites_shifted = true;
-    while (sprites_shifted) {
-        sprites_shifted = false;
-        for (int i = 0; i < MAX_SPRITES - 1; i++) {
-            if (!sprites[i] && sprites[i + 1]) {
-                sprites[i] = sprites[i + 1];
-                sprites[i + 1] = nullptr;
-                sprites_shifted = true;
-            }
-        }
+    if (missing_sprites && warn_if_missing) {
+        dialog("The LGR file has changed since the last edition of this level and",
+               "some pictures do not exist in the LGR file!");
     }
-    return sprites_deleted;
 }
 
 polygon* level::get_closest_vertex(double x, double y, int* vertex_index, double* distance,

--- a/src/level/level.cpp
+++ b/src/level/level.cpp
@@ -79,7 +79,6 @@ const char* get_internal_level_name(int index) {
 
 level::level() {
     level_id = 0;
-    lgr_not_found = false;
     objects_flipped = false;
     topology_errors = false;
     topten_file_offset = 0;
@@ -595,7 +594,6 @@ static bool write_encrypted(void* buffer, int length, FILE* h) {
 }
 
 void level::from_file(const char* filename, bool internal) {
-    lgr_not_found = false;
     objects_flipped = false;
     topology_errors = false;
     topten_file_offset = 0;

--- a/src/pic/lgr.cpp
+++ b/src/pic/lgr.cpp
@@ -83,11 +83,6 @@ static bool lgr_exists(const char* lgr_name, const char* backup_lgr) {
         return false;
     }
 
-    // LGR not found
-    if (!Level) {
-        internal_error("load_lgr_file !Level!");
-    }
-
     // Display warning
     finame filename;
     strcpy(filename, lgr_name);
@@ -148,17 +143,9 @@ void lgrfile::load_lgr_file(const char* lgr_name) {
 
     if (!is_default && !override_is_same) {
         const char* desc = override_is_default ? "default.lgr" : "the default lgr file";
-
         if (try_load_lgr(lgr_load_name, desc)) {
             return;
         }
-
-        if (!Level) {
-            internal_error("load_lgr_file !Level!");
-        }
-
-        LevelChanged = true;
-        strcpy(Level->lgr_name, "default");
     }
 
     if (!override_is_default) {

--- a/src/pic/lgr.cpp
+++ b/src/pic/lgr.cpp
@@ -159,7 +159,6 @@ void lgrfile::load_lgr_file(const char* lgr_name) {
 
         LevelChanged = true;
         strcpy(Level->lgr_name, "default");
-        Level->lgr_not_found = true;
     }
 
     if (!override_is_default) {

--- a/src/renderer/canvas.cpp
+++ b/src/renderer/canvas.cpp
@@ -733,11 +733,11 @@ void canvas::draw_sprites(Clipping clipping) {
             }
             int texture_index = Lgr->get_texture_index(spr->texture_name);
             if (texture_index < 0) {
-                internal_error("draw_sprites texture_index < 0");
+                continue;
             }
             int mask_index = Lgr->get_mask_index(spr->mask_name);
             if (mask_index < 0) {
-                internal_error("draw_sprites mask_index < 0");
+                continue;
             }
             draw_texture(spr, texture_index, mask_index, clipping);
             continue;
@@ -749,7 +749,7 @@ void canvas::draw_sprites(Clipping clipping) {
         // Picture
         int picture_index = Lgr->get_picture_index(spr->picture_name);
         if (picture_index < 0) {
-            internal_error("draw_sprites picture_index < 0");
+            continue;
         }
         picture* pict = &Lgr->pictures[picture_index];
 


### PR DESCRIPTION
This is prep work for features such as 1) live lgr toggling 2) downloading lgrs

To be able to change the lgr in-game, we need to prevent the lgrs from deleting missing pictures/textures. We refactor the lgr/canvas code to skip missing assets instead of deleting assets and crashing on missing assets.

Closes https://github.com/elmadev/elma-classic/issues/623
Closes https://github.com/elmadev/elma-classic/issues/172