### PR TITLE
Fps booster

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@
 ### Gameplay
 * Internal level total time is displayed in menu
 * All internal levels may be immediately unlocked via the Options
+* Game FPS can be boosted to the max of 1000, regardless of the computer's processing power and screen display settings
 * When saving an internal replay, the internal number and name will be shown instead of QWQUU0XX.lev
 * !levinfo prints basic information about the current level
 * Save play is enabled for internal level 55 (More Levels)

--- a/include/eol/settings.h
+++ b/include/eol/settings.h
@@ -147,6 +147,7 @@ class eol_settings {
     Default<bool> show_ups_{false};
     Default<bool> fps_limit_enabled_{false};
     Clamp<int> fps_limit_{30, 100, 1000};
+    Default<bool> fps_boost_{false};
     Clamp<int> recording_fps_{30, 30, 120};
 
     Default<bool> show_demo_menu_{true};
@@ -255,6 +256,7 @@ class eol_settings {
     DECLARE_FIELD_FUNCS(show_ups);
     DECLARE_FIELD_FUNCS(fps_limit_enabled);
     DECLARE_FIELD_FUNCS(fps_limit);
+    DECLARE_FIELD_FUNCS(fps_boost);
     DECLARE_FIELD_FUNCS(recording_fps);
 
     DECLARE_FIELD_FUNCS(show_demo_menu);

--- a/include/physics/pacer.h
+++ b/include/physics/pacer.h
@@ -12,6 +12,9 @@ constexpr double PHYS_MAX_TIMESTEP = 0.0055;
 std::string format_fps_limit();
 
 // Will be updated on the next run
+void toggle_fps_boost();
+
+// Will be updated on the next run
 void request_fps_limit(bool enabled, int limit);
 
 void reset();

--- a/src/eol/console.cpp
+++ b/src/eol/console.cpp
@@ -168,7 +168,6 @@ void console::register_console_commands() {
     REGISTER_SETTINGS_INT(chat_lines);
 
     REGISTER_SETTINGS_BOOL(show_fps);
-
     // eol-client !fps aggregate:
     //   fps         -> toggle show_fps
     //   fps on/off  -> queue limit on/off
@@ -180,7 +179,9 @@ void console::register_console_commands() {
             return;
         }
         std::string s(text);
-        if (strcmpi(s.c_str(), "on") == 0) {
+        if (strcmpi(s.c_str(), "boost") == 0) {
+            pacer::toggle_fps_boost();
+        } else if (strcmpi(s.c_str(), "on") == 0) {
             pacer::request_fps_limit(true, EolSettings->fps_limit());
         } else if (strcmpi(s.c_str(), "off") == 0) {
             pacer::request_fps_limit(false, EolSettings->fps_limit());

--- a/src/eol/settings.cpp
+++ b/src/eol/settings.cpp
@@ -218,6 +218,7 @@ void eol_settings::set_show_fps(bool show) { show_fps_ = show; }
 void eol_settings::set_show_ups(bool show) { show_ups_ = show; }
 void eol_settings::set_fps_limit_enabled(bool b) { fps_limit_enabled_ = b; }
 void eol_settings::set_fps_limit(int fps) { fps_limit_ = fps; }
+void eol_settings::set_fps_boost(bool b) { fps_boost_ = b; }
 void eol_settings::set_recording_fps(int fps) { recording_fps_ = fps; }
 
 void eol_settings::set_show_demo_menu(bool show) { show_demo_menu_ = show; }
@@ -514,6 +515,7 @@ void from_json(const json& j, combo_scancode& r) { r = combo_scancode((unsigned 
     JSON_FIELD(show_ups)                                                                           \
     JSON_FIELD(fps_limit_enabled)                                                                  \
     JSON_FIELD(fps_limit)                                                                          \
+    JSON_FIELD(fps_boost)                                                                          \
     JSON_FIELD(recording_fps)                                                                      \
                                                                                                    \
     JSON_FIELD(show_demo_menu)                                                                     \

--- a/src/menu/options.cpp
+++ b/src/menu/options.cpp
@@ -455,6 +455,7 @@ void menu_options() {
                 static constexpr int steps[] = {60, 100, 144, 240, 500};
                 if (!EolSettings->fps_limit_enabled_persisted()) {
                     EolSettings->persist_fps_limit_enabled(true);
+                    EolSettings->persist_fps_boost(false);
                     EolSettings->persist_fps_limit(steps[0]);
                     return;
                 }
@@ -467,6 +468,15 @@ void menu_options() {
                 }
                 EolSettings->persist_fps_limit_enabled(false);
                 EolSettings->persist_fps_limit(steps[0]);
+            });
+
+        nav.add_row(
+            "Simulate Max FPS:", EolSettings->fps_boost_persisted() ? "Yes" : "No", NAV_FUNC() {
+                bool enabled = !EolSettings->fps_boost_persisted();
+                EolSettings->persist_fps_boost(enabled);
+                if (enabled) {
+                    EolSettings->persist_fps_limit_enabled(false);
+                }
             });
 
         nav.add_row(

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -47,6 +47,19 @@ std::string format_fps_limit() {
     return "";
 }
 
+void toggle_fps_boost() {
+    bool enabled = !EolSettings->fps_boost();
+    if (!EolSettings->show_fps()) {
+        StatusMessages->add(
+            std::format("Turning FPS booster {} when the next run starts", enabled ? "on" : "off"));
+    }
+
+    EolSettings->set_fps_boost(enabled);
+    if (enabled) {
+        EolSettings->set_fps_limit_enabled(false);
+    }
+}
+
 void request_fps_limit(bool enabled, int limit) {
     if (!EolSettings->show_fps()) {
         bool enabled_changed =
@@ -69,6 +82,10 @@ void request_fps_limit(bool enabled, int limit) {
     }
     EolSettings->set_fps_limit_enabled(enabled);
     EolSettings->set_fps_limit(limit);
+
+    if (enabled) {
+        EolSettings->set_fps_boost(false);
+    }
 }
 
 void reset() {

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -14,6 +14,7 @@ constexpr long long LIMITER_TIMEOUT_MS = 33;
 
 bool FpsLimitEnabled = false;
 int FpsLimit = 0;
+bool FpsBoost = false;
 
 // In physics units of time
 double time = 0.0;
@@ -80,6 +81,7 @@ void reset() {
 
     FpsLimitEnabled = EolSettings->fps_limit_enabled();
     FpsLimit = EolSettings->fps_limit();
+    FpsBoost = EolSettings->fps_boost();
 }
 
 void new_frame() {
@@ -110,7 +112,11 @@ bool subframe(double* out_dt) {
     if (0.000001 > dt) {
         return false;
     }
-    dt = std::min(dt, PHYS_MAX_TIMESTEP);
+
+    // Minimum UPS is 79.4, or 1000.0 if booster is enabled
+    const bool boost = FpsBoost && !FpsLimitEnabled;
+    const double max_timestep = boost ? MILLISECONDS_TO_PHYS_TIME : PHYS_MAX_TIMESTEP;
+    dt = std::min(dt, max_timestep);
     *out_dt = dt;
     time += dt;
     return true;

--- a/src/physics/pacer.cpp
+++ b/src/physics/pacer.cpp
@@ -4,6 +4,7 @@
 #include "game/fps.h"
 #include "main.h"
 #include "platform/implementation.h"
+#include <climits>
 #include <format>
 
 namespace pacer {
@@ -29,16 +30,34 @@ long long real_frame_count = 0;
 
 std::string format_fps_limit() {
     bool enabled = pacer::FpsLimitEnabled;
-    int limit = enabled ? pacer::FpsLimit : 0;
+    bool boost = pacer::FpsBoost;
+    int limit = 0;
+    if (enabled) {
+        limit = pacer::FpsLimit;
+    } else if (boost) {
+        limit = INT_MAX;
+    }
+
     bool next_enabled = EolSettings->fps_limit_enabled();
-    int next_limit = next_enabled ? EolSettings->fps_limit() : 0;
+    bool next_boost = EolSettings->fps_boost();
+    int next_limit = 0;
+    if (next_enabled) {
+        next_limit = EolSettings->fps_limit();
+    } else if (next_boost) {
+        next_limit = INT_MAX;
+    }
+
     auto format_limit = [](int limit) -> std::string {
         if (limit == 0) {
             return "off";
         }
+        if (limit == INT_MAX) {
+            return "^1000";
+        }
         return std::to_string(limit);
     };
-    if (enabled || next_enabled) {
+
+    if (enabled || boost || next_enabled || next_boost) {
         if (limit != next_limit) {
             return std::format(" ({} -> {})", format_limit(limit), format_limit(next_limit));
         }


### PR DESCRIPTION
Play at 1000 fixed UPS even with a crappy computer

Even with a screen refresh rate of 1000-1400 you often drop frames, or if your computer has background processes you can drop frames every once in a while, which can be a problem for Uphill Battle. This guarantees 1000 UPS no matter what.

1) I kept FPSLimitEnabled and FPSBoost as separate bools instead of an enum. If we prefer, we could merge them together
2) It's unclear what FPS should display with the booster since currently it's currently showing either frame rate or throttled outer loop rate. Easiest thing would be to just display the UPS if the FPSBoost is on.